### PR TITLE
Added _automatically_removed property to disable automatically fetched fieldsets

### DIFF
--- a/src/components/input/CustomField.js
+++ b/src/components/input/CustomField.js
@@ -217,7 +217,8 @@ class CustomField extends Component {
         generated,
         disabled,
         autofill_readonly,
-        editable
+        editable,
+        automatically_added
       },
       field,
       attributeData,
@@ -237,7 +238,7 @@ class CustomField extends Component {
         attributeData={attributeData}
         name={name}
         placeholder={placeholder || label}
-        disabled={generated || disabled || autofill_readonly || !editable}
+        disabled={generated || disabled || autofill_readonly || !editable || automatically_added}
         formValues={formValues}
         validate={[this.validateFieldSize]}
         syncronousErrors={syncronousErrors}
@@ -427,7 +428,7 @@ class CustomField extends Component {
       name: field.name,
       placeholder: placeHolderText,
       disabled:
-        field.generated || field.disabled || field.autofill_readonly || !field.editable,
+        field.generated || field.disabled || field.autofill_readonly || !field.editable || field.automatically_added,
       component: this.getInput(field),
       ...(field.multiple_choice ? { type: 'select-multiple' } : {}),
       updated: { updated },

--- a/src/components/input/FieldSet.js
+++ b/src/components/input/FieldSet.js
@@ -57,6 +57,7 @@ const FieldSet = ({
     <React.Fragment>
       {sets.map((set, i) => {
         const deleted = get(formValues, set + '._deleted')
+        const automatically_added = get(formValues, set + '._automatically_added')
         return (
           <React.Fragment key={`${name}-${i}`}>
             {!deleted && hiddenIndex !== i && (
@@ -64,7 +65,7 @@ const FieldSet = ({
                 <div className="fieldset-header">
                   <h3 className="fieldset-header-number">{i + 1}.</h3>
 
-                  {!disable_fieldset_delete_add && (
+                  {(!disable_fieldset_delete_add && !automatically_added) && (
                     <IconCross
                       className="fieldset-remove"
                       color="red"
@@ -157,7 +158,7 @@ const FieldSet = ({
                           </div>
                         </div>
                         <CustomField
-                          field={{ ...field, name: currentName, disabled }}
+                          field={{ ...field, name: currentName, disabled, automatically_added }}
                           attributeData={attributeData}
                           fieldset={field.type === 'fieldset'}
                           parentName={name}


### PR DESCRIPTION
Relates to issue where "suunnittelualueella_kiinteisto_fieldset" is updated with properties fetched from Kaavoitus-API