### PR TITLE
Kaav 440 Näkymän kaikki kentät renderöivät kun yhtä kenttää muokkaa

### DIFF
--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -107,7 +107,6 @@ function RichTextEditor(props) {
   }, [])
 
   const handleChange = useCallback((_val, _delta, source) => {
-    console.log("change RichTextEditor")
     if (currentTimeout) {
       clearTimeout(currentTimeout)
       setCurrentTimeout(0)

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -73,10 +73,10 @@ function RichTextEditor(props) {
 
   const [toolbarVisible, setToolbarVisible] = useState(false)
   const editorRef = useRef(null)
-  const [counter, setCounter] = useState(props.currentSize)
-  const [showCounter, setShowCounter] = useState(false)
+  const counter = useRef(props.currentSize)
+  const showCounter = useRef(false)
   const [currentTimeout, setCurrentTimeout] = useState(0)
-  const [inputValue,setInputValue] = useState('')
+  const inputValue = useRef('')
   const fieldFormName = formName ? formName : EDIT_PROJECT_FORM
 
   const getFieldComments = () => {
@@ -99,16 +99,19 @@ function RichTextEditor(props) {
 
   useEffect(() => {
     oldValueRef.current = inputProps.value;
-    setInputValue(inputProps.value);
+    inputValue.current = inputProps.value;
+
     if (setRef) {
       setRef({ name: inputProps.name, ref: editorRef })
     }
   }, [])
 
   const handleChange = useCallback((_val, _delta, source) => {
+    console.log("change RichTextEditor")
     if (currentTimeout) {
       clearTimeout(currentTimeout)
       setCurrentTimeout(0)
+
     }
     if (source === 'user') {
       /* Get the value from the editor - the delta provided to handlechange does not have complete state */
@@ -129,22 +132,22 @@ function RichTextEditor(props) {
               )
             ),
           500
-        )
-      )
+        ))
 
-      setCounter(actualDeltaValue.length() - 1)
-      setShowCounter(true)
+      counter.current = actualDeltaValue.length() - 1;
+      showCounter.current = true;
     }
     inputProps.onChange(_val, inputProps.name);
-    setInputValue(_val);
-  },[inputProps.name, inputProps.value])
+    inputValue.current = _val;
 
-  const handleBlur = () =>{
-    if(inputValue !== oldValueRef.current){
+  }, [inputProps.name, inputProps.value])
+
+  const handleBlur = () => {
+    if (inputValue.current !== oldValueRef.current) {
       onBlur();
-      oldValueRef.current = inputValue;
+      oldValueRef.current = inputValue.current;
     }
- }
+  }
 
   const addComment = () => {
     const prompt = window.prompt(t('shoutbox.add-field-comment'), '')
@@ -180,9 +183,8 @@ function RichTextEditor(props) {
       aria-label="tooltip"
     >
       <div
-        className={`rich-text-editor ${
-          toolbarVisible || showComments ? 'toolbar-visible' : ''
-        } ${largeField ? 'large' : ''}`}
+        className={`rich-text-editor ${toolbarVisible || showComments ? 'toolbar-visible' : ''
+          } ${largeField ? 'large' : ''}`}
         onFocus={() => setToolbarVisible(true)}
       >
         <div
@@ -243,7 +245,7 @@ function RichTextEditor(props) {
               let fixRange = quill.getSelection()
               if (!fixRange) {
                 setToolbarVisible(false)
-                setShowCounter(false)
+                showCounter.current = false;
                 if (onBlur) {
                   handleBlur()
                 }
@@ -274,13 +276,13 @@ function RichTextEditor(props) {
           ))}
         </div>
       )}
-      {showCounter && props.maxSize ? (
+      {showCounter.current && props.maxSize ? (
         <p
           className={
-            counter > props.maxSize ? 'quill-counter quill-warning' : 'quill-counter'
+            counter.current > props.maxSize ? 'quill-counter quill-warning' : 'quill-counter'
           }
         >
-          {counter + '/' + props.maxSize}
+          {counter.current + '/' + props.maxSize}
         </p>
       ) : null}
     </div>

--- a/src/components/input/CustomInput.js
+++ b/src/components/input/CustomInput.js
@@ -11,17 +11,17 @@ const CustomInput = ({ input, meta: { error }, ...custom }) => {
     oldValueRef.current = input.value;
   }, [])
 
-  const handleBlur = (event) =>{
-    if(event.target.value !== oldValueRef.current){
-      custom.onBlur();
-      oldValueRef.current = event.target.value;
-    }
- }
-
   const handleInputChange = useCallback((event) => {
    input.onChange(event, input.name);
 
    }, [input.name, input.value]);
+
+   const handleBlur = (event) =>{
+      if(event.target.value !== oldValueRef.current){
+        custom.onBlur();
+        oldValueRef.current = event.target.value;
+      }
+   }
 
   return (
     <TextInput

--- a/src/components/input/CustomInput.js
+++ b/src/components/input/CustomInput.js
@@ -11,17 +11,17 @@ const CustomInput = ({ input, meta: { error }, ...custom }) => {
     oldValueRef.current = input.value;
   }, [])
 
+  const handleBlur = (event) =>{
+    if(event.target.value !== oldValueRef.current){
+      custom.onBlur();
+      oldValueRef.current = event.target.value;
+    }
+ }
+
   const handleInputChange = useCallback((event) => {
    input.onChange(event, input.name);
 
    }, [input.name, input.value]);
-
-   const handleBlur = (event) =>{
-      if(event.target.value !== oldValueRef.current){
-        custom.onBlur();
-        oldValueRef.current = event.target.value;
-      }
-   }
 
   return (
     <TextInput

--- a/src/components/input/FormField.js
+++ b/src/components/input/FormField.js
@@ -215,4 +215,4 @@ const FormField = ({
   }
 }
 
-export default withTranslation()(React.memo(FormField))
+export default withTranslation()(FormField)


### PR DESCRIPTION
-rich text editor ref instead of state onchange because we do not need re render after value change