### PR TITLE
KAAV-555 updated docker node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.1-alpine3.13 AS builder
+FROM node:14.21-alpine3.16 AS builder
 
 ARG REACT_APP_BASE_URL
 ARG REACT_APP_OPENID_AUDIENCE


### PR DESCRIPTION
-updated docker node version to from 14.16 to 14.21 to prevent build fails with new packages.