### PR TITLE
KAAV-981 Projektiin täytetyt tiedot eivät tallentuneet

### DIFF
--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -387,7 +387,7 @@ function RichTextEditor(props) {
       //set editor value from db value updated with lock call
       const cursorPosition = editorRef.current.getEditor().getSelection()
       editorRef.current.getEditor().setContents(dbValue);
-      editorRef.current.getEditor().setSelection(cursorPosition.index);
+      editorRef.current.getEditor().setSelection(cursorPosition?.index);
     }
   }
 

--- a/src/sagas/projectSaga.js
+++ b/src/sagas/projectSaga.js
@@ -663,7 +663,7 @@ function* unlockAllFields(data) {
    )
  }
  catch (e) {
-   yield put(error(e))
+  yield put(error(e.response.data))
  }
 }
 
@@ -672,7 +672,6 @@ function* unlockProjectField(data) {
   let attribute_identifier = data.payload.inputName;
 
   if(project_name && attribute_identifier){
-
     try {
        yield call(
         attributesApiUnlock.post,
@@ -683,7 +682,7 @@ function* unlockProjectField(data) {
       yield put(setUnlockStatus(lockData,true))
     }
     catch (e) {
-      yield put(error(e))
+      yield put(error(e.response.data))
     }
   }
 }
@@ -708,7 +707,7 @@ function* lockProjectField(data) {
       yield put(setLockStatus(lockData,false,saving))
     }
     catch (e) {
-      yield put(error(e))
+      yield put(error(e.response.data))
     }
   }
 }


### PR DESCRIPTION
prevent routing to error 500 if unlock happens to return multiple attributelock, instead record error and conntinue editing and saving normally.