### PR TITLE
KAAV-748 Aikataulujen muokkaus vaatii jossain tilanteessa väärää formaattia aikakenttiin

### DIFF
--- a/src/components/input/CustomInput.js
+++ b/src/components/input/CustomInput.js
@@ -188,7 +188,7 @@ const CustomInput = ({ input, meta: { error }, ...custom }) => {
       <TextInput
         aria-label={input.name}
         error={inputUtils.hasError(error).toString()}
-        errorText={!custom && inputUtils.hasError(error).toString() || isEmpty ? t('project.error') : ""}
+        errorText={custom.disabled || !inputUtils.hasError(error).toString() || !isEmpty ? "" : t('project.error')}
         fluid="true"
         {...input}
         {...custom}

--- a/src/components/input/CustomInput.js
+++ b/src/components/input/CustomInput.js
@@ -188,7 +188,7 @@ const CustomInput = ({ input, meta: { error }, ...custom }) => {
       <TextInput
         aria-label={input.name}
         error={inputUtils.hasError(error).toString()}
-        errorText={inputUtils.hasError(error).toString() || isEmpty ? t('project.error') : ""}
+        errorText={!custom && inputUtils.hasError(error).toString() || isEmpty ? t('project.error') : ""}
         fluid="true"
         {...input}
         {...custom}

--- a/src/sagas/projectSaga.js
+++ b/src/sagas/projectSaga.js
@@ -618,8 +618,12 @@ function* saveProjectTimetable() {
   if (values) {
     let attribute_data = getChangedAttributeData(values, initial)
 
+    if(attribute_data.oikaisukehoituksen_alainen_readonly){
+      delete attribute_data.oikaisukehoituksen_alainen_readonly
+    }
+    
     const deadlineAttributes = currentProject.deadline_attributes
-
+    
     // Add missing fields as a null to payload since there are
     // fields which can be hidden according the user selection. 
     // If old values are left, it will break the timelines.


### PR DESCRIPTION
-delete attribute_data.oikaisukehoituksen_alainen_readonly when saving dates, is blocking when is set true and is not needed in this data. 
-KAAV-849 input error fields showing when not editing and is empty bug fix.