### PR TITLE
KAAV-1083 Päivämäärien tarkastamisen infolaatikko poistuu liian aikaisin (päättymispäivää ei ole vahvistettu)

### DIFF
--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -75,7 +75,8 @@ function RichTextEditor(props) {
     rollingInfo, 
     modifyText, 
     rollingInfoText,
-    isCurrentPhase
+    isCurrentPhase,
+    selectedPhase
   } = props
 
   const dispatch = useDispatch()
@@ -512,6 +513,7 @@ function RichTextEditor(props) {
       rollingInfoText={rollingInfoText}
       editRollingField={editRollingField}
       isCurrentPhase={isCurrentPhase}
+      selectedPhase={selectedPhase}
     />
     :    
     <div

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -74,7 +74,8 @@ function RichTextEditor(props) {
     nonEditable, 
     rollingInfo, 
     modifyText, 
-    rollingInfoText
+    rollingInfoText,
+    isCurrentPhase
   } = props
 
   const dispatch = useDispatch()
@@ -510,10 +511,11 @@ function RichTextEditor(props) {
       modifyText={modifyText}
       rollingInfoText={rollingInfoText}
       editRollingField={editRollingField}
-      disabled={disabled}
+      isCurrentPhase={isCurrentPhase}
     />
     :    
-    <div 
+    <div
+    onContextMenu={(e)=> {if(readonly){e.preventDefault()}}}
     tabIndex="0"
     onKeyDown={onKeyDown}
     className='richtext-container'
@@ -537,21 +539,21 @@ function RichTextEditor(props) {
           onMouseDown={e => e.preventDefault()}
           className="ql-toolbar"
         >
-          <span className="ql-formats">
+          <span className={readonly ? "ql-formats rich-text-disabled" : "ql-formats"}>
             <button aria-label="bold" className="ql-bold" />
             <button aria-label="italic" className="ql-italic" />
             <button aria-label="underline" className="ql-underline" />
             <button aria-label="strike" className="ql-strike" />
           </span>
-          <span className="ql-formats">
+          <span className={readonly ? "ql-formats rich-text-disabled" : "ql-formats"}>
             <select aria-label="color" className="ql-color" />
             <select aria-label="background" className="ql-background" />
           </span>
-          <span className="ql-formats">
+          <span className={readonly ? "ql-formats rich-text-disabled" : "ql-formats"}>
             <button aria-label="list" className="ql-list" value="ordered" />
             <button aria-label="bullet" className="ql-list" value="bullet" />
           </span>
-          <span className="ql-formats">
+          <span className={readonly ? "ql-formats rich-text-disabled" : "ql-formats"}>
             <button aria-label="script" className="ql-script" value="super" />
             <button aria-label="sub" className="ql-script" value="sub" />
           </span>

--- a/src/components/input/CustomCard.js
+++ b/src/components/input/CustomCard.js
@@ -85,7 +85,9 @@ CustomCard.propTypes = {
   props: PropTypes.object,
   name: PropTypes.string,
   data: PropTypes.object,
-  deadlines: PropTypes.object
+  deadlines: PropTypes.object,
+  placeholder: PropTypes.string,
+  input: PropTypes.object
 }
 
 export default CustomCard

--- a/src/components/input/CustomCard.js
+++ b/src/components/input/CustomCard.js
@@ -70,10 +70,10 @@ CustomCard.propTypes = {
   endInfo: PropTypes.string,
   startModifiedText: PropTypes.string,
   endModifiedText: PropTypes.string,
-  living: PropTypes.string,
-  office: PropTypes.string,
-  general: PropTypes.string,
-  other: PropTypes.string,
+  living: PropTypes.number,
+  office: PropTypes.number,
+  general: PropTypes.number,
+  other: PropTypes.number,
 }
 
 export default CustomCard

--- a/src/components/input/CustomCard.js
+++ b/src/components/input/CustomCard.js
@@ -82,14 +82,10 @@ function CustomCard({type,props,name,data,deadlines}) {
 
 CustomCard.propTypes = {
   type: PropTypes.string,
-  startInfo: PropTypes.string,
-  endInfo: PropTypes.string,
-  startModifiedText: PropTypes.string,
-  endModifiedText: PropTypes.string,
-  living: PropTypes.number,
-  office: PropTypes.number,
-  general: PropTypes.number,
-  other: PropTypes.number,
+  props: PropTypes.object,
+  name: PropTypes.string,
+  data: PropTypes.object,
+  deadlines: PropTypes.object
 }
 
 export default CustomCard

--- a/src/components/input/CustomCard.js
+++ b/src/components/input/CustomCard.js
@@ -1,11 +1,24 @@
-import React from 'react'
+import React, {useEffect,useState} from 'react'
 import PropTypes from 'prop-types'
-import { useDispatch } from 'react-redux';
+import { useDispatch,useSelector } from 'react-redux';
 import {Button,IconPenLine } from 'hds-react'
 import {showFloorArea, showTimetable} from '../../actions/projectActions'
+import {attributeDataSelector} from '../../selectors/projectSelector'
 import { useTranslation } from 'react-i18next'
+import infoFieldUtil from '../../utils/infoFieldUtil'
 
-function CustomCard({type,startInfo,endInfo,startModifiedText,endModifiedText,living,office,general,other}) {
+function CustomCard({type,props,name,data,deadlines}) {
+  const [cardValues, setCardValues] = useState(["","","","",true,0,0,0,0]);
+  const attributeData = useSelector(state => attributeDataSelector(state))
+
+  useEffect(() => {
+    setCardValues(infoFieldUtil.getInfoFieldData(type,name,data,deadlines))
+  }, [])
+
+   useEffect(() => {
+    setCardValues(infoFieldUtil.getInfoFieldData(props.placeholder,props.input?.name,attributeData,deadlines))
+  }, [attributeData])
+
   const dispatch = useDispatch()
   const { t } = useTranslation()
 
@@ -20,11 +33,11 @@ function CustomCard({type,startInfo,endInfo,startModifiedText,endModifiedText,li
     fields = <>  
     <div className='custom-card-info-container'>
       <div className='custom-card-info'>{t('custom-card.when-starts')}</div>
-      <div className='custom-card-date'><span>{startInfo}</span><span className='custom-card-mod'> {startModifiedText ? "- "+t('custom-card.modified') : "- "+t('custom-card.evaluation')}</span></div>
+      <div className='custom-card-date'><span>{cardValues[0]}</span><span className='custom-card-mod'> {cardValues[2] ? "- "+t('custom-card.modified') : "- "+t('custom-card.evaluation')}</span></div>
     </div>
     <div className='custom-card-info-container'>
       <div className='custom-card-info'>{t('custom-card.when-ends')}</div>
-      <div className='custom-card-date'><span>{endInfo}</span><span className='custom-card-mod'> {endModifiedText ? "- "+t('custom-card.modified') : "- "+t('custom-card.evaluation')}</span></div>
+      <div className='custom-card-date'><span>{cardValues[1]}</span><span className='custom-card-mod'> {cardValues[3] ? "- "+t('custom-card.modified') : "- "+t('custom-card.evaluation')}</span></div>
     </div>
     </>
     editDataLink = <Button size='small' iconLeft={<IconPenLine />} onClick={() => dispatch(showTimetable(true))} variant="supplementary" theme="black" role="link">{buttonText}</Button>
@@ -35,25 +48,26 @@ function CustomCard({type,startInfo,endInfo,startModifiedText,endModifiedText,li
     fields = <>  
     <div className='custom-card-info-container'>
       <div className='custom-card-info'>{t('custom-card.living')}</div>
-      <div className='custom-card-floor-info'><span>{living}</span></div>
+      <div className='custom-card-floor-info'><span>{cardValues[5]}</span></div>
     </div>
     <div className='custom-card-info-container'>
       <div className='custom-card-info'>{t('custom-card.office')}</div>
-      <div className='custom-card-floor-info'><span>{office}</span></div>
+      <div className='custom-card-floor-info'><span>{cardValues[6]}</span></div>
     </div>
     <div className='custom-card-info-container'>
       <div className='custom-card-info'>{t('custom-card.public')}</div>
-      <div className='custom-card-floor-info'><span>{general}</span></div>
+      <div className='custom-card-floor-info'><span>{cardValues[7]}</span></div>
     </div>
     <div className='custom-card-info-container'>
       <div className='custom-card-info'>{t('custom-card.other')}</div>
-      <div className='custom-card-floor-info'><span>{other}</span></div>
+      <div className='custom-card-floor-info'><span>{cardValues[8]}</span></div>
     </div>
     </>
     editDataLink = <Button size='small' iconLeft={<IconPenLine />} onClick={() => dispatch(showFloorArea(true))} variant="supplementary" theme="black" role="link">{buttonText}</Button>
   }
 
   return (
+    !cardValues[4] ?
     <div className='custom-card' >
       <div className='heading'>{heading}</div>
       <div className='custom-card-container'>
@@ -61,6 +75,8 @@ function CustomCard({type,startInfo,endInfo,startModifiedText,endModifiedText,li
       </div>
       {editDataLink}
     </div>
+    :
+    ""
   )
 }
 

--- a/src/components/input/CustomCard.js
+++ b/src/components/input/CustomCard.js
@@ -7,7 +7,7 @@ import {attributeDataSelector} from '../../selectors/projectSelector'
 import { useTranslation } from 'react-i18next'
 import infoFieldUtil from '../../utils/infoFieldUtil'
 
-function CustomCard({type,props,name,data,deadlines}) {
+function CustomCard({type, props, name, data, deadlines}) {
   const [cardValues, setCardValues] = useState(["","","","",true,0,0,0,0]);
   const attributeData = useSelector(state => attributeDataSelector(state))
 

--- a/src/components/input/CustomField.js
+++ b/src/components/input/CustomField.js
@@ -748,7 +748,8 @@ CustomField.propTypes = {
     PropTypes.number,
     PropTypes.bool,
     PropTypes.object
-  ])
+  ]),
+  isCurrentPhase:PropTypes.bool
 }
 
 export default CustomField

--- a/src/components/input/CustomField.js
+++ b/src/components/input/CustomField.js
@@ -60,7 +60,7 @@ class CustomField extends Component {
 
   renderNumber = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, insideFieldset,
-      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
     return (
     <CustomInput 
       min={0} 
@@ -78,6 +78,7 @@ class CustomField extends Component {
       modifyText={modifyText}
       rollingInfoText={rollingInfoText}
       isCurrentPhase={isCurrentPhase}
+      selectedPhase={selectedPhase}
       />
     )
   }
@@ -85,7 +86,7 @@ class CustomField extends Component {
   renderYearSelect = props => {
     const { multiple_choice, placeholder_text } = this.props.field
     const { handleBlurSave, handleLockField, handleUnlockField, formName, lockField, fieldSetDisabled, 
-      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase} = this.props
+      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase} = this.props
 
     if (this.yearOptions.length === 0) {
       this.yearOptions = projectUtils.generateArrayOfYears()
@@ -109,13 +110,14 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
     )
   }
 
   renderString = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, insideFieldset, 
-      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
     return( 
       <CustomInput 
         lockField={lockField} 
@@ -132,6 +134,7 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
     )
   }
@@ -143,7 +146,7 @@ class CustomField extends Component {
 
   renderRichText = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, meta, formName, lockField, unlockAllFields, fieldSetDisabled,
-      insideFieldset,nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+      insideFieldset,nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
     return (
       <RichTextEditor
         lockField={lockField}
@@ -163,13 +166,14 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
     )
   }
 
   renderRichTextShort = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, meta, setRef, lockField,unlockAllFields,fieldSetDisabled,
-      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
     return (
       <RichTextEditor 
         lockField={lockField} 
@@ -188,13 +192,14 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
     )
   }
 
   renderDate = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, deadlines, field, lockField, fieldSetDisabled, 
-      insideFieldset, disabled, isProjectTimetableEdit, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+      insideFieldset, disabled, isProjectTimetableEdit, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
 
     let current
     if (deadlines && deadlines.length > 0) {
@@ -231,6 +236,7 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
     )
   }
@@ -243,7 +249,7 @@ class CustomField extends Component {
   renderSelect = props => {
     const { choices, multiple_choice, placeholder_text, formName } = this.props.field
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, 
-      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
 
     return (
       <SelectInput
@@ -264,6 +270,7 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
     )
   }
@@ -298,7 +305,7 @@ class CustomField extends Component {
   }
 
   renderBooleanRadio = props => {
-    const { input, onRadioChange, defaultValue, disabled, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+    const { input, onRadioChange, defaultValue, disabled, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
     
     return (
       <RadioBooleanButton
@@ -313,6 +320,7 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
         {...props}
       />
     )
@@ -324,7 +332,7 @@ class CustomField extends Component {
   }
 
   renderLink = props => {
-    const { handleBlurSave, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+    const { handleBlurSave, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
     const { placeholder_text } = this.props.field
 
     return (
@@ -337,6 +345,7 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
         {...props} 
       />
     )
@@ -406,7 +415,7 @@ class CustomField extends Component {
 
   renderDecimal = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, insideFieldset,
-      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
+      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase, selectedPhase } = this.props
     return (
       <CustomInput 
         type="number" 
@@ -424,6 +433,7 @@ class CustomField extends Component {
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
     )
   }

--- a/src/components/input/CustomField.js
+++ b/src/components/input/CustomField.js
@@ -60,7 +60,7 @@ class CustomField extends Component {
 
   renderNumber = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, insideFieldset,
-      nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
     return (
     <CustomInput 
       min={0} 
@@ -76,7 +76,8 @@ class CustomField extends Component {
       nonEditable={nonEditable}
       rollingInfo={rollingInfo}
       modifyText={modifyText}
-      rollingInfoText={rollingInfoText} 
+      rollingInfoText={rollingInfoText}
+      isCurrentPhase={isCurrentPhase}
       />
     )
   }
@@ -84,7 +85,7 @@ class CustomField extends Component {
   renderYearSelect = props => {
     const { multiple_choice, placeholder_text } = this.props.field
     const { handleBlurSave, handleLockField, handleUnlockField, formName, lockField, fieldSetDisabled, 
-      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText} = this.props
+      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase} = this.props
 
     if (this.yearOptions.length === 0) {
       this.yearOptions = projectUtils.generateArrayOfYears()
@@ -106,14 +107,15 @@ class CustomField extends Component {
         nonEditable={nonEditable}
         rollingInfo={rollingInfo}
         modifyText={modifyText}
-        rollingInfoText={rollingInfoText} 
+        rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
       />
     )
   }
 
   renderString = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, insideFieldset, 
-      nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
     return( 
       <CustomInput 
         lockField={lockField} 
@@ -129,6 +131,7 @@ class CustomField extends Component {
         rollingInfo={rollingInfo}
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
       />
     )
   }
@@ -140,7 +143,7 @@ class CustomField extends Component {
 
   renderRichText = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, meta, formName, lockField, unlockAllFields, fieldSetDisabled,
-      insideFieldset,nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+      insideFieldset,nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
     return (
       <RichTextEditor
         lockField={lockField}
@@ -159,13 +162,14 @@ class CustomField extends Component {
         rollingInfo={rollingInfo}
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
       />
     )
   }
 
   renderRichTextShort = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, meta, setRef, lockField,unlockAllFields,fieldSetDisabled,
-      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
     return (
       <RichTextEditor 
         lockField={lockField} 
@@ -183,13 +187,14 @@ class CustomField extends Component {
         rollingInfo={rollingInfo}
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
       />
     )
   }
 
   renderDate = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, deadlines, field, lockField, fieldSetDisabled, 
-      insideFieldset, disabled, isProjectTimetableEdit, nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+      insideFieldset, disabled, isProjectTimetableEdit, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
 
     let current
     if (deadlines && deadlines.length > 0) {
@@ -225,6 +230,7 @@ class CustomField extends Component {
         rollingInfo={rollingInfo}
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
       />
     )
   }
@@ -237,7 +243,7 @@ class CustomField extends Component {
   renderSelect = props => {
     const { choices, multiple_choice, placeholder_text, formName } = this.props.field
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, 
-      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+      insideFieldset, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
 
     return (
       <SelectInput
@@ -257,6 +263,7 @@ class CustomField extends Component {
         rollingInfo={rollingInfo}
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
       />
     )
   }
@@ -291,7 +298,7 @@ class CustomField extends Component {
   }
 
   renderBooleanRadio = props => {
-    const { input, onRadioChange, defaultValue, disabled, nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+    const { input, onRadioChange, defaultValue, disabled, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
     
     return (
       <RadioBooleanButton
@@ -304,7 +311,8 @@ class CustomField extends Component {
         nonEditable={nonEditable}
         rollingInfo={rollingInfo}
         modifyText={modifyText}
-        rollingInfoText={rollingInfoText} 
+        rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
         {...props}
       />
     )
@@ -316,7 +324,7 @@ class CustomField extends Component {
   }
 
   renderLink = props => {
-    const { handleBlurSave, nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+    const { handleBlurSave, nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
     const { placeholder_text } = this.props.field
 
     return (
@@ -327,7 +335,8 @@ class CustomField extends Component {
         nonEditable={nonEditable}
         rollingInfo={rollingInfo}
         modifyText={modifyText}
-        rollingInfoText={rollingInfoText} 
+        rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
         {...props} 
       />
     )
@@ -397,7 +406,7 @@ class CustomField extends Component {
 
   renderDecimal = props => {
     const { handleBlurSave, handleLockField, handleUnlockField, lockField, fieldSetDisabled, insideFieldset,
-      nonEditable, rollingInfo, modifyText, rollingInfoText } = this.props
+      nonEditable, rollingInfo, modifyText, rollingInfoText, isCurrentPhase } = this.props
     return (
       <CustomInput 
         type="number" 
@@ -414,6 +423,7 @@ class CustomField extends Component {
         rollingInfo={rollingInfo}
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
+        isCurrentPhase={isCurrentPhase}
       />
     )
   }

--- a/src/components/input/CustomField.js
+++ b/src/components/input/CustomField.js
@@ -18,12 +18,10 @@ import CustomCheckbox from './CustomCheckbox'
 
 import AutofillInputCalculations from './AutofillInputCalculation/AutofillInputCalculations'
 
-import { isEqual } from 'lodash'
+import { isEqual,get } from 'lodash'
 import projectUtils from '../../utils/projectUtils'
-import infoFieldUtil from '../../utils/infoFieldUtil'
 import AutofillInput from './AutofillInput/AutofillInput'
 import DeadlineInfoText from './DeadlineInfoText'
-import { get } from 'lodash'
 import { EDIT_PROJECT_TIMETABLE_FORM } from '../../constants'
 import CustomADUserCombobox from './CustomADUserCombobox'
 import CustomSearchCombobox from './CustomSearchCombobox'
@@ -493,39 +491,27 @@ class CustomField extends Component {
   }
 
   renderInfoFieldset = props => {
-    const name = props.input?.name
-    const data = this.props.attributeData
-    const deadlines = this.props.deadlines
-    const placeholder = props.placeholder
-
-    const [startDate,endDate,startModified,endModified,hide,living,office,general,other] = infoFieldUtil.getInfoFieldData(placeholder,name,data,deadlines)
     //Date informations
-    if(placeholder === "Tarkasta esilläolopäivät"){
+    if(props.placeholder === "Tarkasta esilläolopäivät"){
       return (
-        !hide ?
         <CustomCard
           props={props}
-          type={placeholder}
-          startInfo={startDate}
-          startModifiedText={startModified}
-          endModifiedText={endModified}
-          endInfo={endDate}
+          type={props.placeholder}
+          name={props.input?.name}
+          data={this.props.attributeData}
+          deadlines={this.props.deadlines}
         />
-        : ""
       )
     }//Floor area informations
-    else if(placeholder === "Tarkasta kerrosalatiedot"){
+    else if(props.placeholder === "Tarkasta kerrosalatiedot"){
       return (
-        !hide ?
         <CustomCard
-          type={placeholder}
+          type={props.placeholder}
           props={props}
-          living={living || 0}
-          office={office || 0}
-          general={general || 0}
-          other={other || 0}
+          name={props.input?.name}
+          data={this.props.attributeData}
+          deadlines={this.props.deadlines}
         />
-        : ""
       )
     }
   }

--- a/src/components/input/CustomField.js
+++ b/src/components/input/CustomField.js
@@ -759,7 +759,8 @@ CustomField.propTypes = {
     PropTypes.bool,
     PropTypes.object
   ]),
-  isCurrentPhase:PropTypes.bool
+  isCurrentPhase:PropTypes.bool,
+  selectedPhase: PropTypes.number
 }
 
 export default CustomField

--- a/src/components/input/CustomInput.js
+++ b/src/components/input/CustomInput.js
@@ -211,7 +211,7 @@ const CustomInput = ({ input, meta: { error }, ...custom }) => {
         modifyText={custom.modifyText}
         rollingInfoText={custom.rollingInfoText}
         editRollingField={editRollingField}
-        disabled={custom.disabled}
+        isCurrentPhase={custom.isCurrentPhase}
       />
       :    
       <div className={custom.disabled || !inputUtils.hasError(error).toString() || !isEmpty ? "text-input " : "text-input " +t('project.error')}>

--- a/src/components/input/CustomInput.js
+++ b/src/components/input/CustomInput.js
@@ -212,6 +212,7 @@ const CustomInput = ({ input, meta: { error }, ...custom }) => {
         rollingInfoText={custom.rollingInfoText}
         editRollingField={editRollingField}
         isCurrentPhase={custom.isCurrentPhase}
+        selectedPhase={custom.selectedPhase}
       />
       :    
       <div className={custom.disabled || !inputUtils.hasError(error).toString() || !isEmpty ? "text-input " : "text-input " +t('project.error')}>

--- a/src/components/input/FormField.js
+++ b/src/components/input/FormField.js
@@ -36,6 +36,7 @@ const FormField = ({
   deadlines,
   isProjectTimetableEdit,
   rollingInfo,
+  isCurrentPhase,
   ...rest
 }) => {
   const [lockStatus, setLockStatus] = useState({})
@@ -110,6 +111,7 @@ const FormField = ({
             modifyText={t('project.modify')}
             rollingInfoText={rollingInfoText}
             nonEditable={nonEditable}
+            isCurrentPhase={isCurrentPhase}
           />
         )
     }

--- a/src/components/input/FormField.js
+++ b/src/components/input/FormField.js
@@ -37,6 +37,7 @@ const FormField = ({
   isProjectTimetableEdit,
   rollingInfo,
   isCurrentPhase,
+  selectedPhase,
   ...rest
 }) => {
   const [lockStatus, setLockStatus] = useState({})
@@ -112,6 +113,7 @@ const FormField = ({
             rollingInfoText={rollingInfoText}
             nonEditable={nonEditable}
             isCurrentPhase={isCurrentPhase}
+            selectedPhase={selectedPhase}
           />
         )
     }

--- a/src/components/input/FormField.js
+++ b/src/components/input/FormField.js
@@ -293,7 +293,8 @@ FormField.propTypes = {
   field: PropTypes.object,
   deadlines:PropTypes.object,
   isProjectTimetableEdit:PropTypes.bool,
-  rollingInfo:PropTypes.bool
+  rollingInfo:PropTypes.bool,
+  isCurrentPhase:PropTypes.bool
 }
 
 export default withTranslation()(FormField)

--- a/src/components/input/FormField.js
+++ b/src/components/input/FormField.js
@@ -296,7 +296,8 @@ FormField.propTypes = {
   deadlines:PropTypes.object,
   isProjectTimetableEdit:PropTypes.bool,
   rollingInfo:PropTypes.bool,
-  isCurrentPhase:PropTypes.bool
+  isCurrentPhase:PropTypes.bool,
+  selectedPhase: PropTypes.number
 }
 
 export default withTranslation()(FormField)

--- a/src/components/input/Link.js
+++ b/src/components/input/Link.js
@@ -64,6 +64,7 @@ const Link = props => {
         rollingInfoText={props.rollingInfoText}
         editRollingField={editRollingField}
         isCurrentPhase={props.isCurrentPhase}
+        selectedPhase={props.selectedPhase}
       />
       :    
       <div className="link-container">

--- a/src/components/input/Link.js
+++ b/src/components/input/Link.js
@@ -63,6 +63,7 @@ const Link = props => {
         modifyText={props.modifyText}
         rollingInfoText={props.rollingInfoText}
         editRollingField={editRollingField}
+        isCurrentPhase={props.isCurrentPhase}
       />
       :    
       <div className="link-container">

--- a/src/components/input/RadioBooleanButton.js
+++ b/src/components/input/RadioBooleanButton.js
@@ -16,7 +16,8 @@ const RadioBooleanButton = ({
   rollingInfo, 
   modifyText, 
   rollingInfoText,
-  isCurrentPhase
+  isCurrentPhase,
+  selectedPhase
 }) => {
   const [radioValue, setRadioValue] = useState(null)
   const [editField,setEditField] = useState(false)
@@ -62,6 +63,7 @@ const RadioBooleanButton = ({
         rollingInfoText={rollingInfoText}
         editRollingField={editRollingField}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
       : 
       <div className={className}>

--- a/src/components/input/RadioBooleanButton.js
+++ b/src/components/input/RadioBooleanButton.js
@@ -15,7 +15,8 @@ const RadioBooleanButton = ({
   nonEditable, 
   rollingInfo, 
   modifyText, 
-  rollingInfoText
+  rollingInfoText,
+  isCurrentPhase
 }) => {
   const [radioValue, setRadioValue] = useState(null)
   const [editField,setEditField] = useState(false)
@@ -60,7 +61,7 @@ const RadioBooleanButton = ({
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         editRollingField={editRollingField}
-        disabled={disabled || timeTableDisabled}
+        isCurrentPhase={isCurrentPhase}
       />
       : 
       <div className={className}>

--- a/src/components/input/RollingInfo.js
+++ b/src/components/input/RollingInfo.js
@@ -2,7 +2,7 @@ import React from 'react'
 import {IconPenLine,IconCheckCircle,Button } from 'hds-react'
 import PropTypes from 'prop-types'
 
-function RollingInfo({value,nonEditable,modifyText,rollingInfoText,editRollingField,disabled}) {
+function RollingInfo({value,nonEditable,modifyText,rollingInfoText,editRollingField,isCurrentPhase}) {
 
   const openEdit = () => {
     editRollingField()
@@ -13,7 +13,7 @@ function RollingInfo({value,nonEditable,modifyText,rollingInfoText,editRollingFi
       <div className={value === "" ? "text-input-italic" : "text-input"}>
         <div className='content'>{value === "" ? "Tieto puuttuu." : value}</div>
       </div>
-      {nonEditable || disabled ? 
+      {nonEditable || !isCurrentPhase ? 
       <></> : 
       <Button onClick={() => {openEdit()}} size="small" variant="supplementary" iconLeft={<IconPenLine />}>
         {modifyText}
@@ -32,7 +32,8 @@ RollingInfo.propTypes = {
   nonEditable: PropTypes.bool,
   modifyText: PropTypes.string,
   rollingInfoText: PropTypes.string,
-  editRollingField: PropTypes.func
+  editRollingField: PropTypes.func,
+  isCurrentPhase:PropTypes.bool
 }
 
 export default RollingInfo

--- a/src/components/input/RollingInfo.js
+++ b/src/components/input/RollingInfo.js
@@ -2,26 +2,33 @@ import React from 'react'
 import {IconPenLine,IconCheckCircle,Button } from 'hds-react'
 import PropTypes from 'prop-types'
 
-function RollingInfo({value,nonEditable,modifyText,rollingInfoText,editRollingField,isCurrentPhase}) {
+function RollingInfo({value,nonEditable,modifyText,rollingInfoText,editRollingField,isCurrentPhase,selectedPhase}) {
+
+  //Starting page code for different sized projects(xs-xl)
+  const firstPhase = selectedPhase === 1 || selectedPhase === 7 || selectedPhase === 13 || selectedPhase === 19 || selectedPhase === 25
 
   const openEdit = () => {
     editRollingField()
   }
+
   return (
     <>
     <div className='rolling-info-container'>
       <div className={value === "" ? "text-input-italic" : "text-input"}>
         <div className='content'>{value === "" ? "Tieto puuttuu." : value}</div>
       </div>
-      {nonEditable || !isCurrentPhase ? 
+      {nonEditable || !firstPhase && !isCurrentPhase ? 
       <></> : 
       <Button onClick={() => {openEdit()}} size="small" variant="supplementary" iconLeft={<IconPenLine />}>
         {modifyText}
       </Button>}
     </div>
+    {!nonEditable && !firstPhase && !isCurrentPhase ?
+    <div className='rolling-text'></div> :
     <div className='rolling-text'>
       <IconCheckCircle aria-hidden="true" /><span>{rollingInfoText}</span>
     </div>
+    }
   </>
   )
 }
@@ -33,7 +40,8 @@ RollingInfo.propTypes = {
   modifyText: PropTypes.string,
   rollingInfoText: PropTypes.string,
   editRollingField: PropTypes.func,
-  isCurrentPhase:PropTypes.bool
+  isCurrentPhase:PropTypes.bool,
+  selectedPhase:PropTypes.number
 }
 
 export default RollingInfo

--- a/src/components/input/SelectInput.js
+++ b/src/components/input/SelectInput.js
@@ -25,7 +25,8 @@ const SelectInput = ({
   rollingInfo, 
   modifyText, 
   rollingInfoText,
-  isCurrentPhase
+  isCurrentPhase,
+  selectedPhase
 }) => {
   const currentValue = []
   const oldValueRef = useRef('');
@@ -252,6 +253,7 @@ const SelectInput = ({
         rollingInfoText={rollingInfoText}
         editRollingField={editRollingField}
         isCurrentPhase={isCurrentPhase}
+        selectedPhase={selectedPhase}
       />
       :    
       !multiple ?

--- a/src/components/input/SelectInput.js
+++ b/src/components/input/SelectInput.js
@@ -24,7 +24,8 @@ const SelectInput = ({
   nonEditable, 
   rollingInfo, 
   modifyText, 
-  rollingInfoText
+  rollingInfoText,
+  isCurrentPhase
 }) => {
   const currentValue = []
   const oldValueRef = useRef('');
@@ -250,7 +251,7 @@ const SelectInput = ({
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}
         editRollingField={editRollingField}
-        disabled={disabled}
+        isCurrentPhase={isCurrentPhase}
       />
       :    
       !multiple ?

--- a/src/components/project/EditFloorAreaFormModal/index.js
+++ b/src/components/project/EditFloorAreaFormModal/index.js
@@ -60,9 +60,7 @@ class EditFloorAreaFormModal extends Component {
     const { saving, initialize, formValues } = this.props
     /* handle submit success / failure */
 
-    if (prevProps.submitting && this.props.submitSucceeded) {
-      this.handleClose()
-    } else if (
+    if (
       prevProps.submitting &&
       this.props.submitFailed &&
       !this.props.submitSucceeded &&
@@ -72,11 +70,6 @@ class EditFloorAreaFormModal extends Component {
     }
     if (prevProps.saving && !saving) {
       initialize(formValues)
-    }
-
-    if(this.props.isFloorAreaSaved){
-      this.setState({ loading: false })
-      this.props.handleClose()
     }
   }
 
@@ -88,7 +81,6 @@ class EditFloorAreaFormModal extends Component {
   }
 
   handleClose = () => {
-    this.props.reset()
     this.props.handleClose()
     this.setState({ loading: false })
   }
@@ -139,7 +131,6 @@ class EditFloorAreaFormModal extends Component {
       <Modal
         className="form-modal edit-floor-area-form-modal"
         size={'small'}
-        onClose={this.props.handleClose}
         open={this.props.open}
         closeIcon
       >

--- a/src/components/project/EditProjectTimetableModal/index.js
+++ b/src/components/project/EditProjectTimetableModal/index.js
@@ -49,23 +49,14 @@ class EditProjectTimeTableModal extends Component {
       saving,
       initialize,
       attributeData,
-      submitSucceeded,
       submitFailed
     } = this.props
 
-    /* handle submit success / failure */
-
-    if (prevProps.submitting && submitSucceeded) {
-      this.handleClose()
-      this.props.destroy()
-    } else if (prevProps.submitting && submitFailed) {
+    if (prevProps.submitting && submitFailed) {
       this.setLoadingFalse()
     }
     if (prevProps.saving && !saving) {
       initialize(attributeData)
-    }
-    if(this.props.isTimetableSaved){
-      this.props.handleClose()
     }
   }
 
@@ -206,7 +197,6 @@ class EditProjectTimeTableModal extends Component {
       <Modal
         className="form-modal edit-project-timetable-form-modal"
         size="small"
-        onClose={this.handleClose}
         open={open}
         closeIcon={false}
         closeOnDocumentClick={false}

--- a/src/components/project/EditProjectTimetableModal/index.js
+++ b/src/components/project/EditProjectTimetableModal/index.js
@@ -246,7 +246,8 @@ EditProjectTimeTableModal.propTypes = {
   handleClose: PropTypes.func.isRequired,
   projectPhaseIndex: PropTypes.number,
   currentProject: PropTypes.object,
-  archived: PropTypes.bool
+  archived: PropTypes.bool,
+  submitting: PropTypes.bool
 }
 
 const mapStateToProps = state => ({

--- a/src/components/projectEdit/EditForm.js
+++ b/src/components/projectEdit/EditForm.js
@@ -74,7 +74,8 @@ class EditForm extends Component {
       fieldCount,
       showSection,
       deadlines,
-      isCurrentPhase
+      isCurrentPhase,
+      selectedPhase
     } = this.props
     return (
       <>
@@ -101,6 +102,7 @@ class EditForm extends Component {
             fieldCount={fieldCount}
             deadlines={deadlines}
             isCurrentPhase={isCurrentPhase}
+            selectedPhase={selectedPhase}
           />
         <Button
           variant="supplementary"

--- a/src/components/projectEdit/EditForm.js
+++ b/src/components/projectEdit/EditForm.js
@@ -124,7 +124,8 @@ class EditForm extends Component {
 
 EditForm.propTypes = {
   deadlines:PropTypes.object,
-  isCurrentPhase:PropTypes.bool
+  isCurrentPhase:PropTypes.bool,
+  selectedPhase: PropTypes.number
 }
 
 const decoratedForm = reduxForm({

--- a/src/components/projectEdit/EditForm.js
+++ b/src/components/projectEdit/EditForm.js
@@ -73,7 +73,8 @@ class EditForm extends Component {
       highlightedTag,
       fieldCount,
       showSection,
-      deadlines
+      deadlines,
+      isCurrentPhase
     } = this.props
     return (
       <>
@@ -99,6 +100,7 @@ class EditForm extends Component {
             highlightedTag={highlightedTag}
             fieldCount={fieldCount}
             deadlines={deadlines}
+            isCurrentPhase={isCurrentPhase}
           />
         <Button
           variant="supplementary"

--- a/src/components/projectEdit/EditForm.js
+++ b/src/components/projectEdit/EditForm.js
@@ -121,7 +121,8 @@ class EditForm extends Component {
 }
 
 EditForm.propTypes = {
-  deadlines:PropTypes.object
+  deadlines:PropTypes.object,
+  isCurrentPhase:PropTypes.bool
 }
 
 const decoratedForm = reduxForm({

--- a/src/components/projectEdit/FormSection.js
+++ b/src/components/projectEdit/FormSection.js
@@ -30,7 +30,8 @@ const FormSection = ({
   filterFieldsArray,
   highlightedTag,
   deadlines,
-  isCurrentPhase
+  isCurrentPhase,
+  selectedPhase
 }) => {
   let count = 0;
   if(section?.title && section?.fields){
@@ -76,6 +77,7 @@ const FormSection = ({
             deadlines={deadlines}
             rollingInfo={rollingInfo}
             isCurrentPhase={isCurrentPhase}
+            selectedPhase={selectedPhase}
           />)
         }
         else{

--- a/src/components/projectEdit/FormSection.js
+++ b/src/components/projectEdit/FormSection.js
@@ -92,7 +92,8 @@ const FormSection = ({
 
 FormSection.propTypes = {
   deadlines:PropTypes.object,
-  isCurrentPhase:PropTypes.bool
+  isCurrentPhase:PropTypes.bool,
+  selectedPhase: PropTypes.number
 }
 
 const mapStateToProps = state => ({

--- a/src/components/projectEdit/FormSection.js
+++ b/src/components/projectEdit/FormSection.js
@@ -89,7 +89,8 @@ const FormSection = ({
 }
 
 FormSection.propTypes = {
-  deadlines:PropTypes.object
+  deadlines:PropTypes.object,
+  isCurrentPhase:PropTypes.bool
 }
 
 const mapStateToProps = state => ({

--- a/src/components/projectEdit/FormSection.js
+++ b/src/components/projectEdit/FormSection.js
@@ -29,7 +29,8 @@ const FormSection = ({
   unlockAllFields,
   filterFieldsArray,
   highlightedTag,
-  deadlines
+  deadlines,
+  isCurrentPhase
 }) => {
   let count = 0;
   if(section?.title && section?.fields){
@@ -74,6 +75,7 @@ const FormSection = ({
             highlightStyle={highlightStyle}
             deadlines={deadlines}
             rollingInfo={rollingInfo}
+            isCurrentPhase={isCurrentPhase}
           />)
         }
         else{

--- a/src/components/projectEdit/index.js
+++ b/src/components/projectEdit/index.js
@@ -692,7 +692,6 @@ class ProjectEditPage extends Component {
               open
               saveProjectFloorArea={saveProjectFloorArea}
               handleClose={() => this.handleFloorAreaClose()}
-              isFloorAreaSaved={this.props.floorAreaSavedSelector}
             />
           )}
           {this.props.showTimetableForm && (

--- a/src/components/projectEdit/index.js
+++ b/src/components/projectEdit/index.js
@@ -669,6 +669,7 @@ class ProjectEditPage extends Component {
             initialValues={Object.assign(attribute_data, geoserver_data)}
             phase={phase}
             selectedPhase={selectedPhase}
+            isCurrentPhase={selectedPhase === phase}
             disabled={formDisabled}
             projectId={id}
             syncronousErrors={syncErrors}

--- a/src/components/projectEdit/index.js
+++ b/src/components/projectEdit/index.js
@@ -701,7 +701,6 @@ class ProjectEditPage extends Component {
               open
               handleSubmit={() => this.handleTimetableSave()}
               handleClose={() => this.handleTimetableClose()}
-              isTimetableSaved={this.props.timetableSavedSelector}
               projectPhaseIndex={projectPhaseIndex}
               archived={currentProject.archived}
             />

--- a/src/reducers/projectReducer.js
+++ b/src/reducers/projectReducer.js
@@ -705,7 +705,8 @@ export const reducer = (state = initialState, action) => {
     case SAVE_PROJECT_FLOOR_AREA_SUCCESSFUL: {
       return{
         ...state,
-        floorAreaSaved: action.payload
+        floorAreaSaved: action.payload,
+        showEditFloorAreaForm: false
       }
     }
 

--- a/src/reducers/projectReducer.js
+++ b/src/reducers/projectReducer.js
@@ -719,7 +719,8 @@ export const reducer = (state = initialState, action) => {
     case SAVE_PROJECT_TIMETABLE_SUCCESSFUL: {
       return{
         ...state,
-        timetableSaved:action.payload
+        timetableSaved:action.payload,
+        showEditProjectTimetableForm: false
       }
     }
 

--- a/src/utils/infoFieldUtil.js
+++ b/src/utils/infoFieldUtil.js
@@ -19,7 +19,7 @@ const getPrincipleDates = (data,deadlines) =>{
   if(data?.vahvista_periaatteet_esillaolo_alkaa_3 === true && data?.vahvista_periaatteet_esillaolo_paattyy_3 === true){
     hide = true
   }
-  if(data?.vahvista_periaatteet_esillaolo_alkaa_2 === true && data?.vahvista_periaatteet_esillaolo_paattyy_2 === true && data?.jarjestetaan_periaatteet_esillaolo_3 && data?.milloin_periaatteet_esillaolo_alkaa_3 && data?.milloin_periaatteet_esillaolo_paattyy_3){
+  else if(data?.vahvista_periaatteet_esillaolo_alkaa_2 === true && data?.vahvista_periaatteet_esillaolo_paattyy_2 === true && data?.jarjestetaan_periaatteet_esillaolo_3 && data?.milloin_periaatteet_esillaolo_alkaa_3 && data?.milloin_periaatteet_esillaolo_paattyy_3){
     startDate = data?.milloin_periaatteet_esillaolo_alkaa_3
     endDate = data?.milloin_periaatteet_esillaolo_paattyy_3
     startModified = userHasModified("milloin_periaatteet_esillaolo_alkaa_3",deadlines,"Periaatteet")
@@ -31,11 +31,14 @@ const getPrincipleDates = (data,deadlines) =>{
     startModified = userHasModified("milloin_periaatteet_esillaolo_alkaa_2",deadlines,"Periaatteet")
     endModified = userHasModified("milloin_periaatteet_esillaolo_paattyy_2",deadlines,"Periaatteet")
   }
-  else if(data?.jarjestetaan_periaatteet_esillaolo_1 && data?.milloin_periaatteet_esillaolo_alkaa && data?.milloin_periaatteet_esillaolo_paattyy){
+  else if(data?.jarjestetaan_periaatteet_esillaolo_1 && !data?.vahvista_periaatteet_esillaolo_alkaa && !data?.vahvista_periaatteet_esillaolo_paattyy && data?.milloin_periaatteet_esillaolo_alkaa && data?.milloin_periaatteet_esillaolo_paattyy){
     startDate = data?.milloin_periaatteet_esillaolo_alkaa
     endDate = data?.milloin_periaatteet_esillaolo_paattyy
     startModified = userHasModified("milloin_periaatteet_esillaolo_alkaa",deadlines,"Periaatteet")
     endModified = userHasModified("milloin_periaatteet_esillaolo_paattyy",deadlines,"Periaatteet")
+  }
+  else{
+    hide = true
   }
 
   return [startDate,endDate,hide,startModified,endModified]
@@ -64,11 +67,14 @@ const getOASDates = (data,deadlines) =>{
     startModified = userHasModified("milloin_oas_esillaolo_alkaa_2",deadlines,"OAS")
     endModified = userHasModified("milloin_oas_esillaolo_paattyy_2",deadlines,"OAS")
   }
-  else if(data?.milloin_oas_esillaolo_alkaa && data?.milloin_oas_esillaolo_paattyy){
+  else if(!data?.vahvista_oas_esillaolo_alkaa && !data?.vahvista_oas_esillaolo_paattyy && data?.milloin_oas_esillaolo_alkaa && data?.milloin_oas_esillaolo_paattyy){
     startDate = data?.milloin_oas_esillaolo_alkaa
     endDate = data?.milloin_oas_esillaolo_paattyy
     startModified = userHasModified("milloin_oas_esillaolo_alkaa",deadlines,"OAS")
     endModified = userHasModified("milloin_oas_esillaolo_paattyy",deadlines,"OAS")
+  }
+  else{
+    hide = true
   }
 
   return [startDate,endDate,hide,startModified,endModified]

--- a/src/utils/infoFieldUtil.js
+++ b/src/utils/infoFieldUtil.js
@@ -93,10 +93,10 @@ const getDraftDates = (data,deadlines) =>{
 
 const getInfoFieldData = (placeholder,name,data,deadlines) => {
   //Floor area info
-  const living = data?.asuminen_yhteensa
-  const office = data?.toimitila_yhteensa
-  const general = data?.julkiset_yhteensa
-  const other = data?.muut_yhteensa
+  const living = data?.asuminen_yhteensa || 0
+  const office = data?.toimitila_yhteensa || 0
+  const general = data?.julkiset_yhteensa || 0
+  const other = data?.muut_yhteensa || 0
 
   //Date info
   let [startDate,endDate,hide,startModified,endModified] = ["","","",false,false]


### PR DESCRIPTION
-Info field dates to hide if dates are confirmed. KAAV-1083
-Richtext disable right click copy paste and toolbar buttons  when locked.  KAAV-1100, KAAV-1107
-Disable rolling info buttons if phase has passed and is not starting phase. KAAV-967
-Hide rolling info text if phase is no longer editable. KAAV-967
-Custom card not updating when modal data is saved fix. KAAV-1084
-Edit floor area and timetable modal not to render twice, moved closing logic from save floor area and timetable to save success reducer so separate close call after save is not needed, cleaned not needed calls from floor area and timetable due to changes.