### PR TITLE
KAAV-1112 Pudotusvalikosta valittu vaihtoehto näkyy virheellisesti tunnisteen muodossa

### DIFF
--- a/src/components/input/SelectInput.js
+++ b/src/components/input/SelectInput.js
@@ -244,13 +244,15 @@ const SelectInput = ({
   
     let notSelectable = readonly === true && fieldName === input.name
     let readOnlyStyle = notSelectable ? 'selection readonly' : 'selection'
+    //Show option texts instead of value ids on multi select for RollingInfo
+    const rollingInfoValue = multiple && currentValue.length ? currentValue?.map(c => c.label) : input.value
     //Render rolling info field or normal edit field
     //If clicking rolling field button makes positive lock check then show normal editable field
     //Rolling field can be nonEditable
     const elements = nonEditable || rollingInfo && !editField ?
       <RollingInfo 
         name={input.name} 
-        value={input.value.toString()} 
+        value={rollingInfoValue}
         nonEditable={nonEditable}
         modifyText={modifyText}
         rollingInfoText={rollingInfoText}

--- a/src/sagas/documentSaga.js
+++ b/src/sagas/documentSaga.js
@@ -46,7 +46,7 @@ function* downloadDocumentSaga({ payload }) {
     payload.projectCard
       ? i18next.t('document-loading.project-card-content')
       : i18next.t('document-loading.document-content'),
-    { closeOnToastrClick: false }
+    { closeOnToastrClick: false, timeOut:0, removeOnHover: false, removeOnHoverTimeOut: 0 }
   )
   try {
     res = yield call(axios.get, payload.file, { responseType: 'json' })
@@ -155,7 +155,7 @@ function* downloadDocumentPreviewSaga({ payload }) {
   toastr.info(
     i18next.t('document-loading.wait-title'),
     i18next.t('document-loading.document-preview-content'),
-    { closeOnToastrClick: false }
+    { closeOnToastrClick: false, timeOut:0, removeOnHover: false, removeOnHoverTimeOut: 0 }
   )
 
   try {


### PR DESCRIPTION
-KAAV-1112 Rollinginfo selects to show value labels instaead of value ids to user.
-KAAV-1206 toastr to be visible untill download is ready