### PR TITLE
Fixed the no fields text and added it to the translation.json.

### DIFF
--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -234,7 +234,8 @@
     "noempty":"Kenttä ei saa olla tyhjä",
     "error":"Virhe",
     "error-prevent-add":"Virhe lomakkeella estää lisäyksen",
-    "fieldset-info":"Yhteensä {{fieldAmount}} tietuetta."
+    "fieldset-info":"Yhteensä {{fieldAmount}} tietuetta.",
+    "no-fields":"Suodatinvalinnalla ei löytynyt tämän otsikon alta suodatettavia kenttiä."
   },
   "nav-header": {
     "latest-update": "Viimeisin muokkaus: {{latestUpdate}}",

--- a/src/components/projectEdit/FormSection.js
+++ b/src/components/projectEdit/FormSection.js
@@ -11,6 +11,7 @@ import { getFormValues } from 'redux-form'
 import { EDIT_PROJECT_FORM } from '../../constants'
 import { Notification } from 'hds-react'
 import PropTypes from 'prop-types'
+import { useTranslation } from "react-i18next";
 
 const FormSection = ({
   section,
@@ -34,6 +35,8 @@ const FormSection = ({
   selectedPhase,
   phaseIsClosed
 }) => {
+  const { t } = useTranslation()
+
   let count = 0;
   if(section?.title && section?.fields){
   return (
@@ -86,7 +89,7 @@ const FormSection = ({
           return <></>
         }
     })}
-    {count === 0 ? <Notification label="Suodatinvalinalla ei löytynyt tämän otsikon alta suodatettavia kenttiä."></Notification> : ""}
+    {count === 0 ? <Notification label={t('project.no-fields')}></Notification> : ""}
     </Segment>
   )
   }


### PR DESCRIPTION
Issue: KAAV-1239