### PR TITLE
KAAV-1396 Infolaatikko: vahvistetuille päivämäärille näkyy yhä "Muokkaa päivämääriä" -painike (vaikka ei pitäisi)

### DIFF
--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -423,7 +423,7 @@
     "office":"Toimitila",
     "public":"Julkiset",
     "other":"Muut",
-    "already-confirmed":"Päivämäärät on jo vahvistettu, jos haluat muuttaa niitä ota yhteys kaavoitussihteeriin.",
+    "already-confirmed":"Päivämäärät ovat jo vahvistettu. Jos haluat muuttaa päivämääriä, ota yhteys kaavoitussihteeriin.",
     "confirmed":"Vahvistettu",
     "principles-board-text":"Milloin periaatteet on lautakunnassa",
     "draft-board-text":"Milloin luonnos on lautakunnassa",

--- a/src/components/input/CustomCard.js
+++ b/src/components/input/CustomCard.js
@@ -88,8 +88,10 @@ function CustomCard({type, props, name, data, deadlines, selectedPhase, showBoth
     }
     </>
 
+    //XL princibles and draft phases have 2 acceptance checkboxes others only one. Selecting all acceptance checkboxes in current phase disables edit button.
+    const disableEdit = selectedPhase === 26 || selectedPhase === 28 ? cardValues[4] && cardValues[10] : cardValues[4] || cardValues[10]
     editDataLink = 
-    cardValues[4] && cardValues[10]
+    disableEdit
     ? 
     <div className='rolling-text'>
       <IconCheckCircle aria-hidden="true" />


### PR DESCRIPTION
disable editform timetable card  edit button when all confirm boxes are selected