### PR TITLE
KAAV-1496 Aikataulujen muokkaus ohjaa tyhjään näkymään

### DIFF
--- a/src/components/project/EditProjectTimetableModal/index.js
+++ b/src/components/project/EditProjectTimetableModal/index.js
@@ -115,6 +115,7 @@ class EditProjectTimeTableModal extends Component {
           className={className}
           isProjectTimetableEdit={true}
           disabled={disabled?.disabled || !this.props.allowedToEdit}
+          attributeData={this.props.attributeData}
         />
         {modifiedError && <div className="field-error">{modifiedError}</div>}
       </div>

--- a/src/components/project/EditProjectTimetableModal/index.js
+++ b/src/components/project/EditProjectTimetableModal/index.js
@@ -248,7 +248,8 @@ EditProjectTimeTableModal.propTypes = {
   currentProject: PropTypes.object,
   archived: PropTypes.bool,
   submitting: PropTypes.bool,
-  allowedToEdit: PropTypes.bool
+  allowedToEdit: PropTypes.bool,
+  attributeData: PropTypes.object,
 }
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
-Timetable modal richtext fields not getting attribute_data fix.