### PR TITLE
KAAV-2073 Change group add to work through getTimelineData, fix newly added groups not updating on timeline

### DIFF
--- a/src/components/ProjectTimeline/VisTimeline.scss
+++ b/src/components/ProjectTimeline/VisTimeline.scss
@@ -513,7 +513,11 @@
         border-bottom: 1px solid #CCCCCC;
     }
 
-    .vis-group-level-0{
+    .vis-label.vis-nested-group{
+        padding-left: 15px;
+    }
+
+    .vis-group-level-0:not(.vis-nested-group){
         display: flex;
         justify-content: flex-start;
         align-items: center;
@@ -525,7 +529,7 @@
         }
     }
 
-    .vis-group-level-0.expanded{
+    .vis-group-level-0.expanded:not(.vis-nested-group){
         padding-left: $size13;
         .vis-inner{
             padding-left: $size8;
@@ -564,7 +568,7 @@
         }
     }
 
-    .vis-group-level-0.collapsed{
+    .vis-group-level-0.collapsed:not(.vis-nested-group){
         padding-left: $size13;
         .vis-inner{
             padding-left: $size8;
@@ -585,7 +589,7 @@
         align-items: center;
         margin-right: -1px;
         height: 35px !important;
-        .vis-group-level-0{
+        .vis-group-level-0:not(.vis-nested-group){
             display: block;
             padding-left: $size16;
         }

--- a/src/components/ProjectTimeline/VisTimelineGroup.js
+++ b/src/components/ProjectTimeline/VisTimelineGroup.js
@@ -14,7 +14,6 @@ import VisTimelineMenu from './VisTimelineMenu'
 import AddGroupModal from './AddGroupModal';
 import ConfirmModal from '../common/ConfirmModal'
 import PropTypes from 'prop-types';
-import { removeDeadlines } from '../../actions/projectActions';
 import { getVisibilityBoolName } from '../../utils/projectVisibilityUtils';
 import './VisTimeline.css'
 Moment().locale('fi');

--- a/src/components/ProjectTimeline/VisTimelineGroup.js
+++ b/src/components/ProjectTimeline/VisTimelineGroup.js
@@ -256,81 +256,10 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
     }
 
     const handleRemoveGroup = () => {
-      //TODO review logic and split this to smaller functions
-      let removeFromTimeline = dataToRemove?.deadlinegroup
-      let phase = dataToRemove?.nestedInGroup.toLowerCase()
-      const esillaolo = dataToRemove?.content?.includes("Esilläolo");
-      const luonnos = dataToRemove?.content?.includes("Lautakunta");
-      //Group that is to be removed
-      let toRemoveFromCalendar = dataToRemove?.nestedInGroup?.toLowerCase() + "_" + dataToRemove?.content?.toLowerCase().replace(/[äöå]/g, match => {
-        switch (match) {
-          case 'ä': return 'a';
-          case 'ö': return 'o';
-          case 'å': return 'a';
-          default: return match;
-        }
-      }).replace(/-/g, "_").replace(/_\d+/g, "");
-
-      let index = "_" + dataToRemove.deadlinegroup.split('_').pop()
-      let keysToRemove = []
-
       const visiblityBool = getVisibilityBoolName(dataToRemove.deadlinegroup)
       if (visiblityBool) {
         dispatch(change(EDIT_PROJECT_TIMETABLE_FORM, visiblityBool, false));
       }
-
-      //remove from attribute data/calendar
-      for (const key in visValues) {
-        if (Object.hasOwn(visValues, key)) {
-          if (
-            (key.includes(toRemoveFromCalendar) && key.includes(index)) || 
-            (esillaolo && key.includes("mielipiteet_" + phase + index)) || 
-            (luonnos && key.includes("kaavaluonnos_") && toRemoveFromCalendar.includes("luonnos_lautakunta") || 
-             luonnos && key.includes("periaatteet_lautakuntaan") && toRemoveFromCalendar.includes("periaatteet_lautakunta")
-            )
-          )
-          {
-            if(luonnos && index === "_1" || esillaolo && index === "_1"){
-              if(!(key.includes("_2") || key.includes("_3") || key.includes("_4"))){
-                keysToRemove.push(key)
-              }
-            }
-            else{
-              keysToRemove.push(key)
-            }
-            // Filter out the matching deadline from deadlines
-            let deleteValue = null
-            if(key.includes("kaavaluonnos_lautakuntaan_") && toRemoveFromCalendar.includes("luonnos_lautakunta") || 
-              key.includes("jarjestetaan_luonnos_esillaolo_") && toRemoveFromCalendar.includes("luonnos_esillaolo") || 
-              key.includes("periaatteet_lautakuntaan_") && toRemoveFromCalendar.includes("periaatteet_lautakunta") || 
-              key.includes("jarjestetaan_periaatteet_esillaolo_") && toRemoveFromCalendar.includes("periaatteet_esillaolo")){
-              deleteValue = false
-            }
-            dispatch(change(EDIT_PROJECT_TIMETABLE_FORM, key, deleteValue));
-          }
-        }
-      }
-      //Remove from vis groups
-      let updatedGroups = groups.get({
-        filter: function(group) {
-          return !(group.deadlinegroup && group.deadlinegroup === removeFromTimeline);
-        }
-      });
-      //Remove from vis sub groups
-      updatedGroups.forEach(group => {
-        if (group.nestedGroups) {
-          group.nestedGroups = group.nestedGroups.filter(subgroup => subgroup !== dataToRemove.id);
-        }
-      });
-      // Remove from local deadlines data, backend removes the actual data on save
-      dispatch(removeDeadlines(keysToRemove));
-      //Remove from vis items
-      const updatedItems = items.get().filter(item => item.group !== dataToRemove.id);
-      //Update timeline visually
-      groups.clear();
-      items.clear();
-      groups.add(updatedGroups);
-      items.add(updatedItems)
       setOpenConfirmModal(!openConfirmModal)
     }
 

--- a/src/components/input/DeadlineInput.js
+++ b/src/components/input/DeadlineInput.js
@@ -180,7 +180,7 @@ const DeadLineInput = ({
     try {
       let field = input.name;
       setCurrentValue(formattedDate)
-      dispatch(updateDateTimeline(field,formattedDate,false,false,deadlineSections));
+      dispatch(updateDateTimeline(field,formattedDate,formValues,false,deadlineSections));
     } catch (error) {
       console.error('Validation error:', error);
     }

--- a/src/components/project/EditProjectTimetableModal/index.js
+++ b/src/components/project/EditProjectTimetableModal/index.js
@@ -105,11 +105,9 @@ class EditProjectTimeTableModal extends Component {
             //Form items and groups
             let [deadLineGroups,nestedDeadlines,phaseData] = this.getTimelineData(deadlineSections,formValues,deadlines,ongoingPhase)
             // Update the existing data
-            let existingGroups = deadLineGroups;
-            existingGroups = nestedDeadlines? existingGroups.concat(nestedDeadlines) : existingGroups
-            console.log("Now setting groups to",existingGroups)
+            const combinedGroups = nestedDeadlines? deadLineGroups.concat(nestedDeadlines) : deadLineGroups
             this.state.groups.clear();
-            this.state.groups.add(existingGroups)
+            this.state.groups.add(combinedGroups)
             this.state.items.update(phaseData)
             const newObjectArray = objectUtil.findDifferencesInObjects(prevProps.formValues,formValues)
 
@@ -1006,7 +1004,8 @@ class EditProjectTimeTableModal extends Component {
   }
 
   addGroup = (changedValues) => {
-    // Get the keys from changedValues
+    // Note: this function may include old/redundant code. TODO: review and remove unnecessary
+    // Groups should be added by dispatching change and regenerating them in getTimelineData
     const keys = Object.keys(changedValues);
     let phase = '';
     let content = '';
@@ -1014,7 +1013,6 @@ class EditProjectTimeTableModal extends Component {
     let idt = "";
     let deadlinegroup = "";
     const groups = this.state.groups.get();
-    let className = "";
     let matchingValues = Object.entries(this.props.formValues);
 
     // Iterate over the keys
@@ -1081,7 +1079,6 @@ class EditProjectTimeTableModal extends Component {
       if (content === "nahtavillaolo") {
         filterContent = "nahtavilla";
       }
-      className = "inner-end";
       let indexKey = '';
       if (index > 2) {
         indexKey = "_" + Number(index - 1);

--- a/src/components/project/EditProjectTimetableModal/index.js
+++ b/src/components/project/EditProjectTimetableModal/index.js
@@ -105,19 +105,11 @@ class EditProjectTimeTableModal extends Component {
             //Form items and groups
             let [deadLineGroups,nestedDeadlines,phaseData] = this.getTimelineData(deadlineSections,formValues,deadlines,ongoingPhase)
             // Update the existing data
-            // Get the existing groups from the state
-            let existingGroups = this.state.groups.get() || deadLineGroups;
-            // Merge nestedDeadlines into deadLineGroups based on deadlineGroup key
-            nestedDeadlines.forEach(nestedDeadline => {
-              let matchingGroup = existingGroups.find(group => group.content.trim().toLowerCase() === nestedDeadline.content.trim().toLowerCase() && group.deadlinegroup.trim().toLowerCase() === nestedDeadline.deadlinegroup.trim().toLowerCase());
-              if (matchingGroup !== -1) {
-                //replace the existing group with the new matching group
-                existingGroups[matchingGroup] = { ...existingGroups[matchingGroup], ...nestedDeadline };
-              } else {
-                existingGroups.push(nestedDeadline);
-              }
-            });
-            this.state.groups.update(existingGroups);
+            let existingGroups = deadLineGroups;
+            existingGroups = nestedDeadlines? existingGroups.concat(nestedDeadlines) : existingGroups
+            console.log("Now setting groups to",existingGroups)
+            this.state.groups.clear();
+            this.state.groups.add(existingGroups)
             this.state.items.update(phaseData)
             const newObjectArray = objectUtil.findDifferencesInObjects(prevProps.formValues,formValues)
 
@@ -1021,7 +1013,6 @@ class EditProjectTimeTableModal extends Component {
     let index = textUtil.getNumberAfterSuffix(Object.keys(changedValues)[0]); //get index from added value, null if not found aka first
     let idt = "";
     let deadlinegroup = "";
-    let groupID = null;
     const groups = this.state.groups.get();
     let className = "";
     let matchingValues = Object.entries(this.props.formValues);
@@ -1039,9 +1030,6 @@ class EditProjectTimeTableModal extends Component {
           phase = phase.charAt(0).toUpperCase() + phase.slice(1);
           phase = phase.replace(/_/g, ' ');
         }
-
-        const group = groups.find(group => phase.toLowerCase() === group.content.toLowerCase());
-        groupID = group ? group.id : null;
         
         //Find correct group by phase and content of vis items
         let filteredGroups = groups.filter(group => {
@@ -1084,10 +1072,6 @@ class EditProjectTimeTableModal extends Component {
             }
             return group;
           });
-  
-          if (updatedGroups.length > 0) {
-            // this.state.groups.add(updatedGroups);
-          }
         }
       }
     }
@@ -1145,153 +1129,18 @@ class EditProjectTimeTableModal extends Component {
     const validValues = this.processValuesSequentially(matchingValues, index, phase);
 
     if (validValues.length >= 2 || validValues.length === 1 && validValues[0].key.includes("_lautakunnassa")) {
-      let newIndex;
       let indexString;
        if (index > 2) {
-        newIndex = index;
         indexString = "_" + index;
       } else {
-        newIndex = "2";
         indexString = "_2";
-      } 
-  
-      let start = null;
-      let end = null;
-      let deadline = null;
-      let atBoard = null;
-      let nahtavillaolo = false;
-  
-      for (let i = 0; i < validValues.length; i++) {
-        if (validValues[i].key.includes("alkaa") || validValues[i].key.includes("alkaa_iso") || validValues[i].key.includes("alkaa_pieni")) {
-          start = new Date(validValues[i].value);
-          start.setHours(12, 0, 0, 0);
-          if (validValues[i].key.includes("nahtavilla")) {
-            nahtavillaolo = true;
-          }
-        } else if (validValues[i].key.includes("paattyy")) {
-          end = new Date(validValues[i].value);
-          end.setHours(12, 0, 0, 0);
-        } else if (validValues[i].key.includes("maaraaika")) {
-          if (validValues[i].key.includes("ehdotus") && (matchingValues.kaavaprosessin_kokoluokka === "XL" || matchingValues.kaavaprosessin_kokoluokka === "L")) {
-            deadline = null;
-          } else {
-            deadline = new Date(validValues[i].value);
-            deadline.setHours(12, 0, 0, 0);
-          }
-        } else if (validValues[i].key.includes("lautakunnassa")) {
-          atBoard = new Date(validValues[i].value);
-          atBoard.setHours(12, 0, 0, 0);
-        }
-        if (start && end && deadline && atBoard) break;
       }
-  
-      if (validValues.length > 2 && deadline) {
-        const deadlineItem = {
-          className: "board",
-          content: "",
-          group: idt,
-          id: this.state.items.length + 1,
-          locked: false,
-          phase: false,
-          phaseID: groupID,
-          start: deadline,
-          type: 'point',
-          title: "maaraaika"
-        };
-        this.state.items.add(deadlineItem);
-  
-        const dividerItem = {
-          className: "divider",
-          content: "",
-          group: idt,
-          id: this.state.items.length + 1,
-          locked: false,
-          phase: false,
-          phaseID: groupID,
-          start: deadline,
-          end: start,
-          title: "divider"
-        };
-        this.state.items.add(dividerItem);
-      }
-  
-      if (start && end) {
-        const newItems = {
-          className: className,
-          content: "",
-          group: idt,
-          id: this.state.items.length + 1,
-          locked: false,
-          phase: false,
-          phaseID: groupID,
-          start: start,
-          end: end,
-          title: content === "esillaolo" || content === "nahtavillaolo" 
-            ? nahtavillaolo === true 
-              ? "milloin_" + phase + "_nahtavillaolo_paattyy" + indexString 
-              : "milloin_" + phase + "_esillaolo_paattyy" + indexString 
-            : phase + "_lautakunta_aineiston_maaraaika" + indexString,
-        };
-        this.state.items.add(newItems);
-      }
-  
-      if (deadline && atBoard && index < 2) {
-        const newItems = {
-          className: "board",
-          content: "",
-          group: idt,
-          id: this.state.items.length + 1,
-          locked: false,
-          phase: false,
-          phaseID: groupID,
-          start: deadline,
-          end: atBoard,
-          title: phase + "_lautakunta_aineiston_maaraaika" + indexString,
-        };
-        this.state.items.add(newItems);
-      }
-  
-      if (atBoard && index > 1) {
-        const boardItem = {
-          className: "board-only",
-          content: "",
-          group: idt,
-          id: this.state.items.length + 1,
-          locked: false,
-          phase: false,
-          phaseID: groupID,
-          start: atBoard,
-          type: 'point',
-          title: "Lautakunta",
-        };
-        this.state.items.add(boardItem);
-      }
-  
-      const newSubGroup = {
-        id: idt,
-        content: content === "esillaolo" || content === "nahtavillaolo" 
-          ? nahtavillaolo === true 
-            ? "Nahtavillaolo-" + newIndex 
-            : "Esilläolo-" + newIndex 
-          : "Lautakunta-" + newIndex,
-        abbreviation: "",
-        deadlinegroup: content === "esillaolo" || content === "nahtavillaolo" 
-          ? nahtavillaolo === true 
-            ? phase + "_nahtavillaolokerta" + indexString 
-            : phase + "_esillaolokerta" + indexString 
-          : phase + "_lautakuntakerta" + indexString,
-        deadlinesubgroup: "",
-        locked: false
-      };
-      this.state.groups.add(newSubGroup);
-  
+      const updateGroups = this.state.groups.get();
       let phaseCapitalized = phase.charAt(0).toUpperCase() + phase.slice(1);
       if (phaseCapitalized === "Tarkistettu_ehdotus") {
         phaseCapitalized = phaseCapitalized.replace(/_/g, ' ');
       }
-      const updateGroups = this.state.groups.get();
       let phaseGroup = updateGroups.find(group => group.content.toLowerCase() === phaseCapitalized.toLowerCase());
-  
       if (phaseGroup?.nestedGroups) {
         const nestedGroupIds = phaseGroup.nestedGroups;
         const nestedGroups = updateGroups.filter(group => nestedGroupIds.includes(group.id));


### PR DESCRIPTION
This ensures that newly added groups are consistent with groups formed during initial render.

For some reason, this approach gives the vis-group-level-0 CSS class to nested deadlines (which should be impossible?), added style rules to accommodate.