### PR TITLE
KAAV-3016 Pre-UAT3: Kaikki vaiheeet 2. lautakuntakerran osa päivistä ei ole valittavissa

### DIFF
--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -167,7 +167,8 @@
     "checking-dates":"Tarkistetaan päivämääriä",
     "dates-confirmed":"Päivämäärät validoitu",
     "error-connection":"Tallennus epäonnistui yhteysongelmia takia. Yritetään uudelleen 10 sekunnin kuluttua.",
-    "error-connection-fail":"Tallennus keskeytyi yhteysongelmia takia."
+    "error-connection-fail":"Tallennus keskeytyi yhteysongelmia takia.",
+    "validation-error":"Päivämäärien tarkistus epäonnistui"
   },
   "floor-areas": {
     "title": "Päivitä kerrosalatiedot",

--- a/src/sagas/projectSaga.js
+++ b/src/sagas/projectSaga.js
@@ -789,7 +789,7 @@ function* validateProjectTimetable() {
       yield put(updateProject(response));
     } catch (e) {
       if (e?.code === 'ERR_NETWORK') {
-        toastr.error(i18.t('messages.general-save-error'));
+        toastr.error(i18.t('messages.validation-error'));
       }
 
       // Catch reached so dates were not correct,

--- a/src/utils/timeUtil.js
+++ b/src/utils/timeUtil.js
@@ -598,7 +598,7 @@ const getDisabledDatesForLautakunta = (name, formValues, phaseName, matchingItem
   } else if (name.includes("_lautakunnassa")) {
     const isPastFirst = formValues[`jarjestetaan_${phaseName}_esillaolo_2`] || formValues[`${phaseName}_lautakuntaan_2`] || formValues[`kaava${phaseName}_lautakuntaan_2`];
     //Tarkistettu ehdotus 2-4 phases have only lautakunta so only 5 days minimum
-    const fromPrevious = phaseName === "tarkistettu_ehdotus" && isPastFirst ? matchingItem?.distance_from_previous : false;
+    const fromPrevious = isPastFirst ? matchingItem?.distance_from_previous : false;
     miniumDaysPast = fromPrevious || (matchingItem?.initial_distance.distance + previousItem?.distance_from_previous);
     if ((phaseName === "periaatteet" || phaseName === "luonnos") && !isPastFirst) {
       dateToComparePast = formValues[previousItem?.previous_deadline] || formValues[previousItem?.initial_distance?.base_deadline];


### PR DESCRIPTION
-Timeline 2-4  board to not use first board minium values.
-Validation failure to show own error message instead of general save error.