### PR TITLE
KAAV-2632 Vahvistus dialogi näytetään vaikka aikatauluun ei ole tehty muutoksia (1.1.1)

### DIFF
--- a/src/components/project/EditProjectTimetableModal/index.js
+++ b/src/components/project/EditProjectTimetableModal/index.js
@@ -1154,7 +1154,13 @@ class EditProjectTimeTableModal extends Component {
   }
 
   openConfirmCancel = () => {
-    this.setState({ showModal: true });
+    // Only show confirmation dialog if changes have been made
+    if (!isEqual(this.props.attributeData, this.props.formValues)) {
+      this.setState({ showModal: true });
+    } else {
+      // No changes, so we can just close without confirmation
+      this.handleClose();
+    }
   }
 
   handleContinueCancel = () => {


### PR DESCRIPTION
-Timeline confirm dialog on cancel to only show up if changes have been made.