### PR TITLE
KAAV-2207 Elementtirivien toimintalogiikan lisävaatimukset (muut paitsi dialogi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 !.yarn/versions
 .idea/*
 **.css.map
+
+#AI Ignore GitHub configuration directory
+.github/

--- a/src/components/ProjectTimeline/AddGroupModal.jsx
+++ b/src/components/ProjectTimeline/AddGroupModal.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types'
 const AddGroupModal = ({toggleOpenAddDialog,addDialogStyle,addDialogData,closeAddDialog, allowedToEdit, timelineAddButton, phaseIsClosed}) => {
   const {t} = useTranslation()
   const dispatch = useDispatch();
-  console.log(phaseIsClosed)
+  
   const addNew = (addedKey) => {
     if(addedKey) {
       dispatch(change(EDIT_PROJECT_TIMETABLE_FORM, addedKey, true));

--- a/src/components/ProjectTimeline/AddGroupModal.jsx
+++ b/src/components/ProjectTimeline/AddGroupModal.jsx
@@ -6,10 +6,10 @@ import { IconPlus,Button } from 'hds-react'
 import { useTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
 
-const AddGroupModal = ({toggleOpenAddDialog,addDialogStyle,addDialogData,closeAddDialog, allowedToEdit, timelineAddButton}) => {
+const AddGroupModal = ({toggleOpenAddDialog,addDialogStyle,addDialogData,closeAddDialog, allowedToEdit, timelineAddButton, phaseIsClosed}) => {
   const {t} = useTranslation()
   const dispatch = useDispatch();
-
+  console.log(phaseIsClosed)
   const addNew = (addedKey) => {
     if(addedKey) {
       dispatch(change(EDIT_PROJECT_TIMETABLE_FORM, addedKey, true));

--- a/src/components/ProjectTimeline/TimelineModal.jsx
+++ b/src/components/ProjectTimeline/TimelineModal.jsx
@@ -305,7 +305,6 @@ const TimelineModal = ({ open,group,content,deadlinegroup,deadlines, onClose,vis
 
       const phaseIndexForGroup = phaseList.findIndex(p => _normalize(p) === _normalize(group));
       const phaseIsActive = phaseIndexForGroup === projectPhaseIndex;
-      console.log(phaseIsActive,sectionIndex,projectPhaseIndex)
             // New rule: In active phase, Lautakunta cannot be confirmed before Esilläolo is confirmed
       let esillaoloNotConfirmedBeforeLautakunta = false;
       if (phaseIsActive && isLautakunta && lastEsillaolo) {

--- a/src/components/ProjectTimeline/TimelineModal.jsx
+++ b/src/components/ProjectTimeline/TimelineModal.jsx
@@ -250,6 +250,24 @@ const TimelineModal = ({ open,group,content,deadlinegroup,deadlines, onClose,vis
       return confirmedValue.replace(/\s+/g, '');
     };
 
+    // Simplified past-date check: only use phase start date `${phaseKey}vaihe_alkaa_pvm`.
+    const isEsillaoloOrNahtavillaStartDateInPast = (group, title, visValues) => {
+      let phaseKey;
+      if (group === 'Ehdotus') phaseKey = 'ehdotus';
+      else if (group === 'Tarkistettu ehdotus') phaseKey = 'tarkistettu_ehdotus';
+      else if (group === 'Luonnos') phaseKey = 'luonnos';
+      else if (group === 'OAS') phaseKey = 'oas';
+      else if (group === 'Periaatteet') phaseKey = 'periaatteet';
+      else phaseKey = group?.toLowerCase().replace(/\s+/g,'_');
+
+      const key = `${phaseKey}vaihe_alkaa_pvm`;
+      const dateStr = visValues?.[key];
+      if (!dateStr) return false;
+      const dt = new Date(dateStr);
+      if (isNaN(dt)) return false;
+      return dt < new Date();
+    };
+
     const getSectionRestrictions = ({
       group,
       title,
@@ -274,6 +292,7 @@ const TimelineModal = ({ open,group,content,deadlinegroup,deadlines, onClose,vis
       const isLastNahtavillaolo = isNahtavillaolo && (_normalize(title) === _normalize(lastNahtavillaolo));
 
       const lautakuntaInPast = isLautakunta && isLautakuntaDateInPast(group, title, visValues);
+      const esillaoloNahtavillaInPast = (isEsillaolo || isNahtavillaolo) && isEsillaoloOrNahtavillaStartDateInPast(group, title, visValues);
       const phaseClosed = isPhaseClosed(group);
 
       const disableConfirmButton = phaseClosed
@@ -284,9 +303,41 @@ const TimelineModal = ({ open,group,content,deadlinegroup,deadlines, onClose,vis
             (isNahtavillaolo && !isLastNahtavillaolo)
           );
 
+      const phaseIndexForGroup = phaseList.findIndex(p => _normalize(p) === _normalize(group));
+      const phaseIsActive = phaseIndexForGroup === projectPhaseIndex;
+      console.log(phaseIsActive,sectionIndex,projectPhaseIndex)
+            // New rule: In active phase, Lautakunta cannot be confirmed before Esilläolo is confirmed
+      let esillaoloNotConfirmedBeforeLautakunta = false;
+      if (phaseIsActive && isLautakunta && lastEsillaolo) {
+        // Build confirm key for the last Esilläolo block
+        const esillaoloConfirmKey = getConfirmedValue(group, lastEsillaolo);
+        const esillaoloConfirmed = !!visValues[esillaoloConfirmKey];
+        if (!esillaoloConfirmed) {
+          esillaoloNotConfirmedBeforeLautakunta = true;
+        }
+      }
+            // Rule 2: Esilläolo confirmation cannot be cancelled while a Lautakunta is confirmed
+      let esillaoloLockedByLautakunta = false;
+      if (phaseIsActive && isEsillaolo && lastLautakunta) {
+        const lautakuntaConfirmKey = getConfirmedValue(group, lastLautakunta);
+        const lautakuntaConfirmed = !!visValues[lautakuntaConfirmKey];
+        if (lautakuntaConfirmed) {
+          const currentEsillaoloConfirmKey = getConfirmedValue(group, title);
+            // Only lock if this Esilläolo is currently confirmed (prevent un-confirm)
+          const currentEsillaoloConfirmed = !!visValues[currentEsillaoloConfirmKey];
+          if (currentEsillaoloConfirmed) {
+            esillaoloLockedByLautakunta = true;
+          }
+        }
+      }
+
       const disabled =
         archived ||
-        disableConfirmButton
+        disableConfirmButton || 
+        !phaseIsActive ||
+        esillaoloNotConfirmedBeforeLautakunta ||
+        esillaoloLockedByLautakunta ||
+        esillaoloNahtavillaInPast
           ? true
           : sectionIndex < projectPhaseIndex;
 
@@ -296,16 +347,18 @@ const TimelineModal = ({ open,group,content,deadlinegroup,deadlines, onClose,vis
         : isNahtavillaolo ? 'nähtävilläolo'
         : 'elementtijoukko';
 
+      // Unify past-date lock for lautakunta and esilläolo/nähtävilläolo; keep prop name for downstream component
+      const anyPast = lautakuntaInPast || esillaoloNahtavillaInPast;
       const tooltip =
         phaseClosed
           ? 'Vahvistusta ei voi perua, koska vaihe on lopetettu.'
-          : lautakuntaInPast
-            ? 'Vahvistusta ei voi perua, koska lautakunta sijaitsee menneessä ajanhetkessä.'
+          : anyPast
+            ? 'Vahvistusta ei voi perua, koska päivämäärä on menneisyydessä.'
             : disableConfirmButton
               ? `Vahvistusta ei voi perua, koska seuraava ${nextGroupWord} on jo lisätty.`
               : null;
 
-      return { lautakuntaInPast, tooltip, disabled };
+      return { lautakuntaInPast: anyPast, tooltip, disabled };
     };
   
     const renderSection = (section,sectionIndex,title) => {

--- a/src/components/ProjectTimeline/VisTimelineGroup.jsx
+++ b/src/components/ProjectTimeline/VisTimelineGroup.jsx
@@ -836,9 +836,7 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
     };
 
     const isPhaseClosed = (phase) => {
-      console.log(phase, phaseList);
       const idx = phaseList.indexOf(phase);
-      console.log(idx,currentPhaseIndex)
       return idx > -1 && idx < currentPhaseIndex;
     };
 
@@ -1155,7 +1153,6 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
                   : `vahvista_${phaseKey}_lautakunnassa_${lautakuntaIndex}`;
                 isConfirmed = visValuesRef?.current[confirmKey] === true;
               }
-              console.log(isPhaseEnded)
               // Tooltip and disable logic
               if (isPhaseEnded) {
                 remove.classList.add("button-disabled");
@@ -1459,7 +1456,7 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
         return content;
       }
     };
-    console.log(addDialogData?.group?.content)
+
     return (
       !deadlines ? <LoadingSpinner />
       :

--- a/src/components/ProjectTimeline/VisTimelineGroup.jsx
+++ b/src/components/ProjectTimeline/VisTimelineGroup.jsx
@@ -836,7 +836,9 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
     };
 
     const isPhaseClosed = (phase) => {
+      console.log(phase, phaseList);
       const idx = phaseList.indexOf(phase);
+      console.log(idx,currentPhaseIndex)
       return idx > -1 && idx < currentPhaseIndex;
     };
 
@@ -1153,7 +1155,7 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
                   : `vahvista_${phaseKey}_lautakunnassa_${lautakuntaIndex}`;
                 isConfirmed = visValuesRef?.current[confirmKey] === true;
               }
-
+              console.log(isPhaseEnded)
               // Tooltip and disable logic
               if (isPhaseEnded) {
                 remove.classList.add("button-disabled");
@@ -1457,7 +1459,7 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
         return content;
       }
     };
-
+    console.log(addDialogData?.group?.content)
     return (
       !deadlines ? <LoadingSpinner />
       :
@@ -1510,6 +1512,7 @@ const VisTimelineGroup = forwardRef(({ groups, items, deadlines, visValues, dead
           closeAddDialog={closeAddDialog}
           allowedToEdit={allowedToEdit}
           timelineAddButton={timelineAddButton}
+          phaseIsClosed={isPhaseClosed(addDialogData?.group?.content)}
         />
         <ConfirmModal
           openConfirmModal={openConfirmModal}

--- a/src/components/input/DeadlineInfoText.jsx
+++ b/src/components/input/DeadlineInfoText.jsx
@@ -122,7 +122,6 @@ const DeadlineInfoText = props => {
   useEffect(() => {
     if (props.input.name.includes("nahtavillaolopaivien_lukumaara")
       && (value !== formValues["nahtavillaolopaivien_lukumaara"])) {
-      console.log(value);
       dispatch(
         autofill(
           EDIT_PROJECT_TIMETABLE_FORM,

--- a/src/components/project/EditProjectTimetableModal/index.jsx
+++ b/src/components/project/EditProjectTimetableModal/index.jsx
@@ -200,7 +200,6 @@ class EditProjectTimeTableModal extends Component {
   }
 
   trimPhase = (phase) => {
-    console.log(phase)
     let phaseOnly = phase.split('.', 2); // Split the string at the first dot
     if (!isNaN(phaseOnly[0])) {  // Check if the part before the dot is a number
       phaseOnly = phaseOnly[1].trim();  // The part after the dot, with leading/trailing spaces removed
@@ -208,7 +207,6 @@ class EditProjectTimeTableModal extends Component {
     if (Array.isArray(phaseOnly)) {
       phaseOnly = phaseOnly.length > 1 ? phaseOnly[1].trim() : phaseOnly[0].trim();
     }
-    console.log(phaseOnly)
     return phaseOnly
   } 
 
@@ -1259,9 +1257,8 @@ class EditProjectTimeTableModal extends Component {
     // Calculate ongoingPhase, phaseList, and currentPhaseIndex here:
     const ongoingPhase = this.trimPhase(attributeData?.kaavan_vaihe);
     const phaseList = this.getPhaseList(attributeData?.kaavaprosessin_kokoluokka);
-    console.log(phaseList)
     const currentPhaseIndex = phaseList.indexOf(ongoingPhase);
-    console.error(ongoingPhase)
+    
     return (
       <Modal
         size="large"

--- a/src/components/project/EditProjectTimetableModal/index.jsx
+++ b/src/components/project/EditProjectTimetableModal/index.jsx
@@ -200,10 +200,15 @@ class EditProjectTimeTableModal extends Component {
   }
 
   trimPhase = (phase) => {
+    console.log(phase)
     let phaseOnly = phase.split('.', 2); // Split the string at the first dot
     if (!isNaN(phaseOnly[0])) {  // Check if the part before the dot is a number
       phaseOnly = phaseOnly[1].trim();  // The part after the dot, with leading/trailing spaces removed
     }
+    if (Array.isArray(phaseOnly)) {
+      phaseOnly = phaseOnly.length > 1 ? phaseOnly[1].trim() : phaseOnly[0].trim();
+    }
+    console.log(phaseOnly)
     return phaseOnly
   } 
 
@@ -1254,8 +1259,9 @@ class EditProjectTimeTableModal extends Component {
     // Calculate ongoingPhase, phaseList, and currentPhaseIndex here:
     const ongoingPhase = this.trimPhase(attributeData?.kaavan_vaihe);
     const phaseList = this.getPhaseList(attributeData?.kaavaprosessin_kokoluokka);
+    console.log(phaseList)
     const currentPhaseIndex = phaseList.indexOf(ongoingPhase);
-
+    console.error(ongoingPhase)
     return (
       <Modal
         size="large"


### PR DESCRIPTION
Vahvistus:

Aikataulut vahvistetaan aikajärjestyksessä Check Mark 

Vahvistus perutaan käänteisessä aikajärjestyksessä Check Mark 

Ei voi vahvistaa jos kyseinen vaihe ei ole käynnissä Check Mark 

Ei voi perua vahvistusta jos seuraava samantyyppinen elementtijoukko lisätty Check Mark 

Ei voi peruuttaa vahvistusta, jos aikataulun päivämäärät ovat menneisyydessä Check Mark 

Lisäys/poisto

Elementtijoukkoja ei voi lisätä eikä poistaa, jos vaihe on ohitettu Check Mark 

Ei voi poistaa jos vahvistettu Check Mark 

Poistetaan käänteisessä aikajärjestyksessä Check Mark 

Käyttäjälle ilmoitus, miksi ei voi poistaa/lisätä Check Mark 

Lautakuntakertojen tulee olla peräkkäin, eikä niiden välissä voi olla esilläoloja Check Mark 