### PR TITLE
KAAV-3388 generateConfirmedFields ei toimi odotetulla tavalla

### DIFF
--- a/src/sagas/projectSaga.js
+++ b/src/sagas/projectSaga.js
@@ -756,8 +756,8 @@ function* validateProjectTimetable() {
     const phaseNames = [
       'periaatteet',
       'oas',
-      'luonnos',
-      'ehdotus',
+      'kaavaluonnos',
+      'kaavaehdotus',
       'tarkistettu_ehdotus'
     ];
     //Find confirmed fields from attribute_data so backend knows not to edit them
@@ -853,8 +853,8 @@ function* saveProjectTimetable(action,retryCount = 0) {
     const phaseNames = [
       'periaatteet',
       'oas',
-      'luonnos',
-      'ehdotus',
+      'kaavaluonnos',
+      'kaavaehdotus',
       'tarkistettu_ehdotus'
     ];
     

--- a/src/utils/generateConfirmedFields.js
+++ b/src/utils/generateConfirmedFields.js
@@ -1,8 +1,13 @@
 export function generateConfirmedFields(attributeData, confirmationAttributeNames, phaseNames) {
+  // Filter out deprecated vahvista_x_paattyy attributes before processing
+  const filteredConfirmationAttributeNames = confirmationAttributeNames.filter(
+    key => key.includes('_alkaa') || key.includes('_lautakunnassa')
+  );
+
   const confirmedFields = [];
   const seenPhases = new Set();
 
-  confirmationAttributeNames.forEach((confirmationKey) => {
+  filteredConfirmationAttributeNames.forEach((confirmationKey) => {
     if (!attributeData[confirmationKey]) return;
 
     const rawKey = confirmationKey.replace(/^vahvista_/, '');
@@ -24,10 +29,8 @@ export function generateConfirmedFields(attributeData, confirmationAttributeName
       // Special case like vahvista_periaatteet_lautakunnassa
       const field1 = `milloin_${phase}_${base}${finalSuffix}`;
       const field2 = `${phase}_lautakunta_aineiston_maaraaika${finalSuffix}`;
-
       confirmedFields.push(field1);
       confirmedFields.push(field2);
-
       return;
     }
 


### PR DESCRIPTION
Filter deprecated vahvista_paattyy attributes from confirmed fields in projectSaga and generateConfirmedFields