### PR TITLE
KAAV-3517 OAS-vaiheen aikajana meni sekaisin (Esilläolo-2 tulee ennen esilläolo-1)

### DIFF
--- a/src/utils/generateConfirmedFields.js
+++ b/src/utils/generateConfirmedFields.js
@@ -1,6 +1,18 @@
 export function generateConfirmedFields(attributeData, confirmationAttributeNames, phaseNames) {
   const confirmedFields = [];
   const seenPhases = new Set();
+  // Track if first esillaolo (no suffix or _1) is confirmed for each phase
+  const firstEsillaoloConfirmedPhases = new Set();
+
+  // Phase name to phase START boundary field mapping
+  // Note: Only START is protected - END must remain flexible for adding more esilläolos
+  const phaseStartMap = {
+    'periaatteet': 'periaatteetvaihe_alkaa_pvm',
+    'oas': 'oasvaihe_alkaa_pvm',
+    'luonnos': 'luonnosvaihe_alkaa_pvm',
+    'ehdotus': 'ehdotusvaihe_alkaa_pvm',
+    'tarkistettu_ehdotus': 'tarkistettuehdotusvaihe_alkaa_pvm',
+  };
 
   confirmationAttributeNames.forEach((confirmationKey) => {
     if (!attributeData[confirmationKey]) return;
@@ -13,12 +25,17 @@ export function generateConfirmedFields(attributeData, confirmationAttributeName
     const suffix = suffixMatch ? suffixMatch[1] : '';
     const finalSuffix = suffix === '_1' ? '' : suffix;
 
+    // Check if this is the first esillaolo (no suffix or _1 suffix)
+    const isFirstEsillaolo = !suffix || suffix === '_1';
+    if (isFirstEsillaolo && phaseStartMap[phase]) {
+      firstEsillaoloConfirmedPhases.add(phase);
+    }
+
     const keyWithoutSuffix = suffix ? rawKey.slice(0, -suffix.length) : rawKey;
     const base = keyWithoutSuffix.replace(`${phase}_`, '');
 
     const parts = base.split('_');
-    let group = parts[0];
-    let type = parts[1];
+    const group = parts[0];
 
     if (parts.length === 1) {
       // Special case like vahvista_periaatteet_lautakunnassa
@@ -46,6 +63,15 @@ export function generateConfirmedFields(attributeData, confirmationAttributeName
     if (!seenPhases.has(phase) && mielipiteet in attributeData) {
       confirmedFields.push(mielipiteet);
       seenPhases.add(phase);
+    }
+  });
+
+  // Add phase START boundary field when first esillaolo is confirmed
+  // (phase END must remain flexible for adding more esilläolos)
+  firstEsillaoloConfirmedPhases.forEach((phase) => {
+    const startField = phaseStartMap[phase];
+    if (startField && startField in attributeData) {
+      confirmedFields.push(startField);
     }
   });
 


### PR DESCRIPTION
KAAV-3517: Add phase start boundaries to confirmed_fields when first esilläolo is confirmed

Frontend changes:
- Updated generateConfirmedFields.js to include phase START boundary fields in confirmed_fields when the first esilläolo of that phase is confirmed
- Added phaseStartMap mapping phase names to their start boundary field identifiers
- Phase END boundaries are NOT protected (user can still add more esilläolos)

This ensures that when a user confirms the first esilläolo date of a phase, the phase start date becomes locked and won't be recalculated during save.