### PR TITLE
KAAV-3668: Show char limit error alongside connection restored notifcation

### DIFF
--- a/src/components/RichTextEditor/index.jsx
+++ b/src/components/RichTextEditor/index.jsx
@@ -1029,8 +1029,7 @@ function RichTextEditor(props) {
     return (
       <>
         {elements}
-        {/* Hide character limit error when network error is active - network error takes priority */}
-        {maxSizeOver && !hasActiveNetworkError() ? <div className='max-chars-error'>{t('project.charsover')}</div> : ""}
+        {maxSizeOver && network?.status !== 'error' && lastSaved?.status !== 'error' ? <div className='max-chars-error'>{t('project.charsover')}</div> : ""}
         {checking && required && valueIsEmpty ? <div className='max-chars-error'>{t('project.required-field')}</div> : ""}
         <NetworkErrorState fieldName={inputProps.name} maxSizeOver={maxSizeOver} readonly={readonly} />
       </>

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -17,8 +17,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { usersSelector } from '../../selectors/userSelector'
 import { setTestingConnection } from '../../actions/projectActions'
 import { authUserSelector } from '../../selectors/authSelector'
-import { lastSavedSelector,savingSelector,selectedPhaseSelector } from '../../selectors/projectSelector'
-import { networkSelector } from '../../selectors/networkSelector'
+import { lastSavedSelector,savingSelector,selectedPhaseSelector,projectNetworkSelector } from '../../selectors/projectSelector'
 import { schemaSelector } from '../../selectors/schemaSelector'
 import schemaUtils from '../../utils/schemaUtils'
 import {useInterval} from '../../hooks/connectionPoller'
@@ -44,8 +43,8 @@ const Header = props => {
   const saving =  useSelector(state => savingSelector(state))
   const schema = useSelector(state => schemaSelector(state))
   const selectedPhase = useSelector(state => selectedPhaseSelector(state))
-  const network = useSelector(state => networkSelector(state))
-  const isConnectionRestored = network?.status === 'success' || lastSaved?.status === 'connection_restored'
+  const projectNetwork = useSelector(state => projectNetworkSelector(state))
+  const isConnectionRestored = projectNetwork?.status === 'success' || lastSaved?.status === 'connection_restored'
 
   const currentUser = users.find(
     item => user?.profile && item.id === user.profile.sub
@@ -245,6 +244,10 @@ const Header = props => {
 
   const pathToCheck = props.location.pathname
 
+  const saveStatusText = isConnectionRestored && updateTime?.status === t('header.edit-menu-save-fail')
+    ? ''
+    : `${updateTime?.status}${updateTime?.time}`
+
   if(pathToCheck.includes('edit')) {
     return (
       <div className={'edit-page-header' + ((!currentEnv || currentEnv === 'production') ? '' : ' edit-header-dev')}>
@@ -271,7 +274,7 @@ const Header = props => {
               {!saving && !isPollingConnection && updateTime?.status === t('header.edit-menu-save-fail') && !isConnectionRestored ? (
                 <> <IconErrorFill className='error-icon'/> <p className="error">{updateTime?.status}</p> </>
               ) : (
-                !isPollingConnection && <p>{updateTime?.status}{updateTime?.time}</p>
+                !isPollingConnection && <p>{saveStatusText}</p>
               )}
               {!saving && !isPollingConnection && updateTime?.status === t('header.edit-menu-save-fail') && lastSuccessfulSaveTime ? 
                 <Tooltip placement="bottom" className='question-icon'>{t('header.latest-save')}{lastSuccessfulSaveTime}</Tooltip> : ""

--- a/src/components/input/NetworkErrorState.jsx
+++ b/src/components/input/NetworkErrorState.jsx
@@ -87,27 +87,21 @@ export default function NetworkErrorState({ fieldName, validationError, maxSizeO
   const banners = useMemo(() => {
     const notifications = [];
 
-    // PRIORITY 1: Network error  — PRIORITY 2: Backend field error  — PRIORITY 3: Connection restored
     const isNetworkError = lastSaved?.status === 'error';
-    const isConnectionRestored = isSuccess;
-
-    // Client validation error: always takes priority over backend field_error
-    // (user has modified the field — previous backend error is stale)
-    const shouldShowValidationError = hasValidationError && !isNetworkError && !isConnectionRestored;
-
-    if (shouldShowValidationError) {
-      notifications.push({
-        type: 'error',
-        label: normalizeValidationError(validationError, t),
-        key: 'validation'
-      });
-    }
 
     if (isSuccess) {
       notifications.push({
         type: 'success',
         label: t('messages.network-connection-restored-label'),
         key: 'success'
+      });
+    }
+
+    if (hasValidationError && !isNetworkError) {
+      notifications.push({
+        type: 'error',
+        label: normalizeValidationError(validationError, t),
+        key: 'validation'
       });
     }
 

--- a/src/sagas/projectSaga.js
+++ b/src/sagas/projectSaga.js
@@ -315,7 +315,7 @@ function* pollConnection() {
       const formErrors = yield select(formErrorListSelector)
       if (formErrors.includes(fieldName)) {
         yield put(setPoll(true))
-        yield put({ type: SET_NETWORK_STATUS, payload: { status: 'ok', okMessage: '', errorMessage: '' } })
+        yield put({ type: SET_NETWORK_STATUS, payload: { status: 'success', okMessage: 'Yhteys palautunut' } })
         yield put(setSavingField(null))
         yield put(setLastSaved("field_error", time, [fieldName], lastSaved.values || [], false))
         return


### PR DESCRIPTION
This pull request primarily refines how network and validation errors are handled and displayed in the UI, especially in the `Header`, `RichTextEditor`, and `NetworkErrorState` components. The changes improve the prioritization and clarity of error messages, ensure consistency in network status handling, and streamline the display of save statuses.

**Error Handling and UI Display Improvements:**

* Updated the condition for displaying the character limit error in `RichTextEditor` to check both `network` and `lastSaved` statuses, ensuring the error only appears when there are no active network errors.
* Refined the logic for displaying save status text in the `Header` component, hiding it when the connection is restored after a save failure, and replaced direct status/time rendering with a computed `saveStatusText` variable.

**Network Status and Selector Consistency:**

* Switched from using the generic `networkSelector` to `projectNetworkSelector` in the `Header` component to ensure project-specific network status is referenced, and updated related logic accordingly.

**Validation and Network Error Prioritization:**

* Changed the priority logic in `NetworkErrorState` so that validation errors are only shown if there is no network error, and restructured the notification-building logic for clarity and correctness.

**Connection Status Messaging:**

* Updated the connection polling saga to set the network status to `'success'` (with a localized message) instead of `'ok'` when a field error is detected, clarifying the meaning of network recovery.